### PR TITLE
Token can be saved to and loaded from a file

### DIFF
--- a/.idea/keycloak-fetch-bot.iml
+++ b/.idea/keycloak-fetch-bot.iml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/output" />
+    </content>
     <orderEntry type="jdk" jdkName="Python 3.1 (keycloak-fetch-bot)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ pip install .
 # SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install -e .
 ```
 
-Run code
+To run the code you would need a Keycloak instance, you can run one locally or
+in the [cloud](https://developers.redhat.com/developer-sandbox/get-started).
 
 ```bash
 source .venv/bin/activate
 export SSO_API_URL='https://sso-cvaldezr-stage.apps.sandbox.x8i5.p1.openshiftapps.com/'
 export SSO_API_USERNAME=admin
 export SSO_API_PASSWORD=admin
+export SSO_TOKEN_FILENAME=test-token.json
+
+kcfetcher_save_token
 kcfetcher
 ```
 

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -22,12 +22,7 @@ def remove_ids(kc_object={}):
     return kc_object
 
 
-def login(endpoint, user, password, read_token_from_file=False):
-    token = None
-    if not read_token_from_file:
-        token = OpenID.createAdminClient(user, password, endpoint).getToken()
-    else:
-        token = open('./token').read()
+def login(endpoint, token):
     return Keycloak(token, endpoint)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "kcapi>=1.0.24",
+    "kcapi>=1.0.25",
     "importlib_resources",
 ]
 
@@ -20,6 +20,7 @@ repository = "https://github.com/cesarvr/keycloak-fetch-bot"
 
 [project.scripts]
 kcfetcher = "kcfetcher.main:main_cli"
+kcfetcher_save_token = "kcfetcher.main:main_token_save_to_file"
 
 [build-system]
 requires = [


### PR DESCRIPTION
Token is first saved to a file, then token from is used to access Keycloak.

The PR assumes https://github.com/cesarvr/keycloak-api/pull/4 was accepted, and that kcapi==1.0.25 was built.

Token is saved to file by `kcfetcher_save_token` binary.

The old `kcfetcher` binary loads token from file, so it does not need password any more.
The password can still be used as fallback option).

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>
