### PR TITLE
Refresh token can be saved to and loaded from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 output/
 env.sh
 env.env
+test-refresh-token.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.idea/keycloak-fetch-bot.iml
+++ b/.idea/keycloak-fetch-bot.iml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.1 (keycloak-fetch-bot)" jdkType="Python SDK" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/output" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.8 (keycloak-fetch-bot)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.1 (keycloak-fetch-bot)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (keycloak-fetch-bot)" project-jdk-type="Python SDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ pip install .
 # SETUPTOOLS_ENABLE_FEATURES="legacy-editable" pip install -e .
 ```
 
-Run code
+To run the code you would need a Keycloak instance, you can run one locally or
+in the [cloud](https://developers.redhat.com/developer-sandbox/get-started).
 
 ```bash
 source .venv/bin/activate
 export SSO_API_URL='https://sso-cvaldezr-stage.apps.sandbox.x8i5.p1.openshiftapps.com/'
 export SSO_API_USERNAME=admin
 export SSO_API_PASSWORD=admin
+
+# login with username/password, fetch data
 kcfetcher
+
+# login with username/password, save refresh token to file
+SSO_REFRESH_TOKEN_FILENAME=test-refresh-token.json kcfetcher_save_token
+# login with refresh token, fetch data
+SSO_REFRESH_TOKEN_FILENAME=test-refresh-token.json kcfetcher
 ```
 
 ## Development

--- a/kcfetcher/main.py
+++ b/kcfetcher/main.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python
 
 import os
+import sys
+from urllib.parse import urljoin
+from kcapi import OpenID, Token
 
 from kcfetcher.fetch import FetchFactory
 from kcfetcher.store import Store
 from kcfetcher.utils import remove_folder, make_folder, login
+
+
+def main_token_save_to_file():
+    server = os.environ.get('SSO_API_URL', 'https://sso-cvaldezr-stage.apps.sandbox.x8i5.p1.openshiftapps.com/')
+    user = os.environ.get('SSO_API_USERNAME', 'admin')
+    password = os.environ.get('SSO_API_PASSWORD', 'admin')
+    refresh_token_filename = os.environ.get('SSO_REFRESH_TOKEN_FILENAME')
+    token = OpenID.createAdminClient(user, password, server).getToken()
+    if refresh_token_filename:
+        with open(refresh_token_filename, "w") as fout:
+            fout.write(token.refresh_token)
 
 
 def run(output_dir):
@@ -13,10 +27,18 @@ def run(output_dir):
 
     # Credentials
     server = os.environ.get('SSO_API_URL', 'https://sso-cvaldezr-stage.apps.sandbox.x8i5.p1.openshiftapps.com/')
-    user = os.environ.get('SSO_API_USERNAME', 'admin')
-    password = os.environ.get('SSO_API_PASSWORD', 'admin')
+    refresh_token_filename = os.environ.get('SSO_REFRESH_TOKEN_FILENAME')
+    if refresh_token_filename:
+        refresh_token = open(refresh_token_filename, "r").read()
+        realm = "master"
+        well_known = dict(token_endpoint=urljoin(server, f"auth/realms/{realm}/protocol/openid-connect/token"))
+        token = Token(well_known=well_known,refresh_token=refresh_token)
+    else:
+        user = os.environ.get('SSO_API_USERNAME', 'admin')
+        password = os.environ.get('SSO_API_PASSWORD', 'admin')
+        token = OpenID.createAdminClient(user, password, server).getToken()
 
-    kc = login(server, user, password)
+    kc = login(server, token)
     realms = kc.admin()
 
     #  ['keycloak_resource', 'unique identifier']
@@ -53,4 +75,5 @@ def main_cli():
 
 
 if __name__ == '__main__':
-    run()
+    sys.stderr.write("Error: invoke dedicated binaries (`kcfetcher` or `kcfetcher_save_token`) instead of this file.\n")
+    sys.exit(1)

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -22,12 +22,7 @@ def remove_ids(kc_object={}):
     return kc_object
 
 
-def login(endpoint, user, password, read_token_from_file=False):
-    token = None
-    if not read_token_from_file:
-        token = OpenID.createAdminClient(user, password, endpoint).getToken()
-    else:
-        token = open('./token').read()
+def login(endpoint, token):
     return Keycloak(token, endpoint)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/cesarvr/keycloak-fetch-bot"
 
 [project.scripts]
 kcfetcher = "kcfetcher.main:main_cli"
+kcfetcher_save_token = "kcfetcher.main:main_token_save_to_file"
 
 [build-system]
 requires = [


### PR DESCRIPTION
kcfetcher can login to Keycloak also with refresh token

A separate binary is added to help getting refresh token and saving it into file.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>