### PR TITLE
Unit tests for helper.py

### DIFF
--- a/.idea/keycloak-fetch-bot.iml
+++ b/.idea/keycloak-fetch-bot.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.9 (keycloak-fetch-bot)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -10,7 +10,8 @@ def remove_ids(kc_object={}):
             kc_object[index] = remove_ids(kc_object[index])
         return kc_object
 
-    for key in list(kc_object):
+    assert isinstance(kc_object, dict)
+    for key in kc_object:
         if key == 'id' or key == 'flowId':
             del kc_object[key]
             continue

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -17,7 +17,8 @@ def remove_ids(kc_object={}):
             continue
 
         if isinstance(kc_object[key], dict):
-            remove_ids(kc_object[key])
+            # RuntimeError: dictionary changed size during iteration
+            kc_object[key] = remove_ids(kc_object[key])
             continue
 
     return kc_object

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -11,10 +11,7 @@ def remove_ids(kc_object={}):
 
     # each list element needs to be cleaned recursively
     if isinstance(kc_object, list):
-        kc_object_cleaned = list()
-        for obj in kc_object:
-            kc_object_cleaned.append(remove_ids(obj))
-        return kc_object_cleaned
+        return [remove_ids(obj) for obj in kc_object]
 
     # each dict element needs to be cleaned recursively
     assert isinstance(kc_object, dict)

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -15,14 +15,7 @@ def remove_ids(kc_object={}):
 
     # each dict element needs to be cleaned recursively
     assert isinstance(kc_object, dict)
-    kc_object_cleaned = dict()
-    for key in list(kc_object):
-        if key in ['id', 'flowId']:
-            # drop it
-            continue
-        # keep (the cleaned version of) it
-        kc_object_cleaned[key] = remove_ids(kc_object[key])
-    return kc_object_cleaned
+    return {key: remove_ids(kc_object[key]) for key in kc_object if key not in ['id', 'flowId']}
 
 
 def login(endpoint, user, password, read_token_from_file=False):

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -66,8 +66,8 @@ class Test_remove_ids:
             ),
             # and something with flowId
             (
-                    {"k1": "v1", "flowID": "fid-v", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v", "flowId": "fid-v"}]},
-                    {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+                {"k1": "v1", "flowId": "fid-v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v", "flowId": "fid-v2"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
             ),
         ]
     )

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -1,0 +1,20 @@
+import json
+import os
+import shutil
+from kcfetcher.utils.helper import remove_ids, normalize
+# from tests.integration.test_ping import BaseTestClass
+from pytest import mark
+
+
+class Test_normalize:
+    @mark.parametrize(
+        "identifier_in, expected_identifier",
+        [
+            ("myident", "myident"),
+            ("aa/bb cc=dd,ee", "aa_bb_cc_dd_ee"),
+            ("aa/bb cc=dd,ee---aa/bb cc=dd,ee", "aa_bb_cc_dd_ee---aa_bb_cc_dd_ee"),
+        ]
+    )
+    def test_normalize(self, identifier_in, expected_identifier):
+        identifier_out = normalize(identifier_in)
+        assert expected_identifier == identifier_out

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -6,6 +6,76 @@ from kcfetcher.utils.helper import remove_ids, normalize
 from pytest import mark
 
 
+class Test_remove_ids:
+    @mark.parametrize(
+        "kc_object, expected_obj",
+        [
+            ({}, {}),
+            # already clean, simple dict
+            (
+                {"k1": "v1"},
+                {"k1": "v1"},
+            ),
+            (
+                {"k1": "v1", "k2": "v2"},
+                {"k1": "v1", "k2": "v2"},
+            ),
+            # already clean, dict with subdict and sublist
+            (
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            # with id/flowId, simple dict
+            (
+                {"id": "id-v"},
+                {},
+            ),
+            (
+                {"k1": "v1", "id": "id-v"},
+                {"k1": "v1"},
+            ),
+            (
+                {"k1": "v1", "flowId": "fid-v"},
+                {"k1": "v1"},
+            ),
+            # order in dict should not matter, but test this anyway
+            (
+                {"id": "id-v", "k1": "v1"},
+                {"k1": "v1"},
+            ),
+            # with id/flowId, dict with subdict and sublist
+            (
+                {"id": "id-v", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+                {"subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            (
+                {"k1": "v1", "subd": {"k3": "v3", "id": "id-v"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            (
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v", "id": "id-v"}, {"subl2-k": "subl2-v"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            (
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v", "id": "id-v"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            (
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v", "id": "id-v"}]},
+                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+            # and something with flowId
+            (
+                    {"k1": "v1", "flowID": "fid-v", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v", "flowId": "fid-v"}]},
+                    {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"}, {"subl2-k": "subl2-v"}]},
+            ),
+        ]
+    )
+    def test_remove_ids(self, kc_object, expected_obj):
+        obj = remove_ids(kc_object)
+        assert expected_obj == obj
+
+
 class Test_normalize:
     @mark.parametrize(
         "identifier_in, expected_identifier",


### PR DESCRIPTION
Unit tests for `kcfetcher/utils/helper.py` are added by this PR.

While writing test, some corner case we found where tests failed. That was at commit "CI test remove_ids" b447b6094a9b2c2cb2f7cbcb5dea7e7c5997a186. For example this subtest:

```
            (
                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v", "id": "id-v"}, {"subl2-k": "subl2-v"}]},
                {"k1": "v1", "subd": {"k3": "v3"}, "subl": [{"subl1-k": "subl1-v"},                   {"subl2-k": "subl2-v"}]},
            ),
```

I expected the dict inside list `subl` to be removed. This PR now does remove it.

To check this is desired behavior - is there any chance that some dictionaries should contain `id` or `flowId`? 
