### PR TITLE
Hide "Unverified HTTPS request" warnings

### DIFF
--- a/kcfetcher/main.py
+++ b/kcfetcher/main.py
@@ -15,6 +15,10 @@ def run(output_dir):
     server = os.environ.get('SSO_API_URL', 'https://sso-cvaldezr-stage.apps.sandbox.x8i5.p1.openshiftapps.com/')
     user = os.environ.get('SSO_API_USERNAME', 'admin')
     password = os.environ.get('SSO_API_PASSWORD', 'admin')
+    if os.environ.get("KEYCLOAK_API_CA_BUNDLE") == "":
+        # disable annoying warning
+        import requests
+        requests.packages.urllib3.disable_warnings()
 
     kc = login(server, user, password)
     realms = kc.admin()


### PR DESCRIPTION
No need to see messages like "/home/justin_cinkelj/devel/steampunk/dsv/cas/keycloak-fetch-bot/.venv/lib64/python3.9/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host '172.17.0.2'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
"