### PR TITLE
Ci use updated kcapi also for unit tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,6 +11,8 @@ jobs:
       - run: pip install -r requirements-dev.txt
       # install dependencies mentioned in pyproject.toml
       - run: pip install .
+      # TEMP - KC API with fixed "import KcSession"
+      - run: pip install git+https://github.com/cesarvr/keycloak-api.git@d7117c6cdddc4c1497b2cde39d0de3576ad468cc#egg=kcapi
       - run: pytest tests/unit
     env:
       KEYCLOAK_API_CA_BUNDLE:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ build
 twine
 pytest-vcr
 pytest-mock
+pytest-unordered

--- a/tests/unit/fetch/test_client.py
+++ b/tests/unit/fetch/test_client.py
@@ -1,4 +1,5 @@
 from pytest import mark
+from pytest_unordered import unordered
 import json
 import os
 import shutil
@@ -69,7 +70,7 @@ class TestClientFetch_vcr:
 
         # check generated content
         assert os.listdir(datadir) == ["client-0"]
-        assert os.listdir(os.path.join(datadir, "client-0")) == ['master-realm.json', 'roles']
+        assert os.listdir(os.path.join(datadir, "client-0")) == unordered(['master-realm.json', 'roles'])
         assert os.listdir(os.path.join(datadir, "client-0/roles")) == ['roles.json']
         #
         data = json.load(open(os.path.join(datadir, "client-0/master-realm.json")))


### PR DESCRIPTION
I missed specific kcapi commit should be used also for unit tests.

After this I notices directory content is listed in "random" order, so comparison must be unsorted.