### PR TITLE
Fix generic fetch no name attribute

### DIFF
--- a/.github/inject_data.py
+++ b/.github/inject_data.py
@@ -60,7 +60,20 @@ def main():
             "enabled": "true",
             "id": realm_name,
             "realm": realm_name,
+            "displayName": realm_name + "-display-temp",
+            "displayNameHtml": f"<div class=\"kc-logo-text\"><span>{realm_name}</span></div>",
         })
+        # How to reproduce https://github.com/justinc1/keycloak-fetch-bot/issues/19
+        # Test 1:
+        # realm created with:
+        #   displayName=ci0-realm-display - code worked
+        # realm updated to:
+        #   displayName=ci0-realm-displayy - bug exposed
+        # realm updated to:
+        #   displayName=ci0-realm-display - code again works
+        # Looks like on every second update we get bug exposed.
+        # So we do an update.
+        state = master_realm.update(realm_name, {"displayName": realm_name + "-display"}).isOk()
 
     roles = kc.build('roles', realm_name)
     for role_name in role_names_plain:

--- a/.idea/keycloak-fetch-bot.iml
+++ b/.idea/keycloak-fetch-bot.iml
@@ -3,9 +3,10 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/kcfetcher" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.9 (keycloak-fetch-bot)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (keycloak-fetch-bot)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (keycloak-fetch-bot)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (keycloak-fetch-bot)" project-jdk-type="Python SDK" />
 </project>

--- a/kcfetcher/fetch/__init__.py
+++ b/kcfetcher/fetch/__init__.py
@@ -4,6 +4,7 @@ from .client_scope import ClientScopeFetch
 from .custom_authentication import CustomAuthenticationFetch
 from .user import UserFetch
 from .user_federation import UserFederationFetch
+from .component import ComponentFetch
 from .factory import FetchFactory
 
 __all__ = [

--- a/kcfetcher/fetch/component.py
+++ b/kcfetcher/fetch/component.py
@@ -1,0 +1,39 @@
+from kcfetcher.fetch import GenericFetch
+
+"""
+Whole component fetch is temporal thing.
+Likely every component type should be moved to a dedicated class,
+until nothing is left for ComponentFetch.
+
+Most components (at least those that are part of realm by default) have "name" attribute.
+But some don't have it, example:
+    {'id': '81c8c815-0d3a-480f-a6ee-3c6f7324a8cb', 'providerId': 'declarative-user-profile', 'providerType': 'org.keycloak.userprofile.UserProfileProvider', 'parentId': 'ci0-realm', 'config': {}}
+
+The missing "name" would usually by typo, we want to ignore this only in very specific cases.
+"""
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class ComponentFetch(GenericFetch):
+    def __init__(self, kc, resource_name, resource_id="", realm=""):
+        super().__init__(kc, resource_name, resource_id, realm)
+        assert "components" == self.resource_name
+        assert "name" == self.id
+
+    def all(self, kc):
+        objects = kc.all()
+        forbidden_provider_types = ["org.keycloak.userprofile.UserProfileProvider"]
+        objects2 = []
+        for obj in objects:
+            if "providerType" in obj and obj["providerType"] in forbidden_provider_types:
+                # This one has no name, so do not check the name
+                # We just drop it for now
+                assert 'name' not in obj
+                logger.warning(f"Component {obj} was not saved, it has no name.")
+                continue
+            if obj[self.id] in self.black_list:
+                continue
+            objects2.append(obj)
+        return objects2

--- a/kcfetcher/fetch/factory.py
+++ b/kcfetcher/fetch/factory.py
@@ -1,5 +1,5 @@
 from kcfetcher.fetch import CustomAuthenticationFetch, ClientFetch, GenericFetch, UserFetch, ClientScopeFetch,\
-    UserFederationFetch
+    UserFederationFetch, ComponentFetch
 
 
 class FetchFactory:
@@ -10,6 +10,7 @@ class FetchFactory:
             'client-scopes': ClientScopeFetch,
             'users': UserFetch,
             'user-federations': UserFederationFetch,
+            'components': ComponentFetch,
         }
 
     def create(self, resource, kc, realm):

--- a/kcfetcher/main.py
+++ b/kcfetcher/main.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
 
+import logging
 import os
 
 from kcfetcher.fetch import FetchFactory
 from kcfetcher.store import Store
 from kcfetcher.utils import remove_folder, make_folder, login
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s.%(msecs)d %(levelname)-8s %(name)s [%(filename)s:%(lineno)d]: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+logger = logging.getLogger(__name__)
 
 
 def run(output_dir):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "kcapi>=1.0.27",
+    "kcapi>=1.0.28",
     "importlib_resources",
 ]
 

--- a/tests/unit/fetch/cassettes/TestComponentFetch.test_fetch.yaml
+++ b/tests/unit/fetch/cassettes/TestComponentFetch.test_fetch.yaml
@@ -1,0 +1,157 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/realms/master/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"issuer":"https://172.17.0.2:8443/auth/realms/master","authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth","token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","end_session_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/logout","jwks_uri":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/certs","check_session_iframe":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba"],"response_types_supported":["code","none","id_token","token","id_token
+        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","address","phone","profile","web-origins","offline_access","roles","email","microprofile-jwt"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
+    headers:
+      Cache-Control:
+      - no-cache, must-revalidate, no-transform, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5646'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Nov 2022 13:05:44 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: client_id=admin-cli&grant_type=password&realm=master&username=admin&password=admin
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
+  response:
+    body:
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJNcWlkZzJxdFg1ZVExcF9GZy1GZVAzQUxqM1FNcWdTeUZHdWZSNUNtQzdrIn0.eyJleHAiOjE2Njc5MTI4MDQsImlhdCI6MTY2NzkxMjc0NCwianRpIjoiMWVhZjVmNGMtZTYyNS00MjFkLWI0M2ItNmYzZDMxNGY1NjEyIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiZjIxZDYwMjAtODE3Ni00ZTFmLWJlZmYtOGQyYWUzZjkwZWQwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6ImZlNjMzZjQzLTQ4MzAtNGI5Yi1iNTZmLTIyZmNhODI3ZmE5OCIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiJmZTYzM2Y0My00ODMwLTRiOWItYjU2Zi0yMmZjYTgyN2ZhOTgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.edhltQfcvX3_EyrOxRu3SNHE6Pqv6cc0W9gcy32NSU6iOirdLSPJRf0Q-ow2dZ1cBog5fw-vW0dejgv47YMuH1rePgv6bayqHmnb_c4_YlVYHKxZPZUVf-sXfzYWJZ91XSn4vb_FWED6WZ94GoyZ5M7Ff8V4cMukafdJmJ-bIqGu1aBLECZmPKP_WplWCtyHnkplWqom0aS9D1eTXTxjr8GnKOGLAYSJL0qdIHHVzSu4eRecOaD0CUePErUR6Fwy17lfkLbBFw4Dp9H6ewBrhBp8CQYCGlvduH7G3_8mVwJPpYVuIkZYyYT_zo9WRsv9yzgIcCGJM-YY8xf0uK-3Zg","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiMmRlYjQ1Mi1lNzg1LTQ1OWMtODdlZS0xMGVlODIyM2FhNjAifQ.eyJleHAiOjE2Njc5MTQ1NDQsImlhdCI6MTY2NzkxMjc0NCwianRpIjoiOGIyMmFiYTUtNmU4Ny00YzBkLTk4NjMtODUyYWY5NjljMDZkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiZjIxZDYwMjAtODE3Ni00ZTFmLWJlZmYtOGQyYWUzZjkwZWQwIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJmZTYzM2Y0My00ODMwLTRiOWItYjU2Zi0yMmZjYTgyN2ZhOTgiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiJmZTYzM2Y0My00ODMwLTRiOWItYjU2Zi0yMmZjYTgyN2ZhOTgifQ.vKEA4pdnwijU3fH51yGjYjc0digT_WswkRZcx3aHRLI","token_type":"Bearer","not-before-policy":0,"session_state":"fe633f43-4830-4b9b-b56f-22fca827fa98","scope":"profile
+        email"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1846'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Nov 2022 13:05:44 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Set-Cookie:
+      - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
+        00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
+      - KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
+        Path=/auth/realms/master/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJNcWlkZzJxdFg1ZVExcF9GZy1GZVAzQUxqM1FNcWdTeUZHdWZSNUNtQzdrIn0.eyJleHAiOjE2Njc5MTI4MDQsImlhdCI6MTY2NzkxMjc0NCwianRpIjoiMWVhZjVmNGMtZTYyNS00MjFkLWI0M2ItNmYzZDMxNGY1NjEyIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiZjIxZDYwMjAtODE3Ni00ZTFmLWJlZmYtOGQyYWUzZjkwZWQwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6ImZlNjMzZjQzLTQ4MzAtNGI5Yi1iNTZmLTIyZmNhODI3ZmE5OCIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiJmZTYzM2Y0My00ODMwLTRiOWItYjU2Zi0yMmZjYTgyN2ZhOTgiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.edhltQfcvX3_EyrOxRu3SNHE6Pqv6cc0W9gcy32NSU6iOirdLSPJRf0Q-ow2dZ1cBog5fw-vW0dejgv47YMuH1rePgv6bayqHmnb_c4_YlVYHKxZPZUVf-sXfzYWJZ91XSn4vb_FWED6WZ94GoyZ5M7Ff8V4cMukafdJmJ-bIqGu1aBLECZmPKP_WplWCtyHnkplWqom0aS9D1eTXTxjr8GnKOGLAYSJL0qdIHHVzSu4eRecOaD0CUePErUR6Fwy17lfkLbBFw4Dp9H6ewBrhBp8CQYCGlvduH7G3_8mVwJPpYVuIkZYyYT_zo9WRsv9yzgIcCGJM-YY8xf0uK-3Zg
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/components
+  response:
+    body:
+      string: '[{"id":"c6f15f7b-60ec-425a-bc82-673487e27100","name":"Allowed Protocol
+        Mapper Types","providerId":"allowed-protocol-mappers","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{"allowed-protocol-mapper-types":["saml-user-property-mapper","oidc-sha256-pairwise-sub-mapper","oidc-full-name-mapper","oidc-usermodel-attribute-mapper","oidc-usermodel-property-mapper","saml-role-list-mapper","saml-user-attribute-mapper","oidc-address-mapper"]}},{"id":"cc97b6da-9c76-434c-aa27-1193f00e5638","name":"email","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["mail"],"is.mandatory.in.ldap":["false"],"always.read.value.from.ldap":["false"],"read.only":["true"],"user.model.attribute":["email"]}},{"id":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","name":"ci0-uf1-ldap","providerId":"ldap","providerType":"org.keycloak.storage.UserStorageProvider","parentId":"ci0-realm","config":{"fullSyncPeriod":["-1"],"pagination":["true"],"connectionPooling":["true"],"usersDn":["uid"],"cachePolicy":["DEFAULT"],"useKerberosForPasswordAuthentication":["false"],"importEnabled":["true"],"enabled":["true"],"bindCredential":["**********"],"bindDn":["admin1"],"changedSyncPeriod":["-1"],"usernameLDAPAttribute":["uid"],"vendor":["rhds"],"uuidLDAPAttribute":["nsuniqueid"],"connectionUrl":["ldaps://172.17.0.5:636"],"allowKerberosAuthentication":["false"],"syncRegistrations":["false"],"authType":["simple"],"debug":["false"],"searchScope":["1"],"useTruststoreSpi":["ldapsOnly"],"priority":["0"],"trustEmail":["false"],"userObjectClasses":["inetOrgPerson,
+        organizationalPerson"],"rdnLDAPAttribute":["uid"],"validatePasswordPolicy":["false"],"batchSizeForSync":["1001"]}},{"id":"c8334a72-45f5-4cdf-a9da-61cc24823ea7","name":"rsa-enc-generated","providerId":"rsa-generated","providerType":"org.keycloak.keys.KeyProvider","parentId":"ci0-realm","config":{"keyUse":["enc"],"priority":["100"]}},{"id":"fd3c0119-acac-45ab-827e-7733aae2ec4e","name":"Allowed
+        Protocol Mapper Types","providerId":"allowed-protocol-mappers","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"authenticated","config":{"allowed-protocol-mapper-types":["oidc-sha256-pairwise-sub-mapper","oidc-usermodel-property-mapper","saml-user-property-mapper","saml-role-list-mapper","oidc-address-mapper","oidc-full-name-mapper","saml-user-attribute-mapper","oidc-usermodel-attribute-mapper"]}},{"id":"9ec4f063-bbd3-43de-a15e-698e6c8708c3","name":"email","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["mail"],"is.mandatory.in.ldap":["false"],"read.only":["true"],"always.read.value.from.ldap":["false"],"user.model.attribute":["email"]}},{"id":"7e2f2669-287d-4a7a-8e7d-b25b5d60f829","name":"aes-generated","providerId":"aes-generated","providerType":"org.keycloak.keys.KeyProvider","parentId":"ci0-realm","config":{"priority":["100"]}},{"id":"2f576047-6734-46fb-bc46-209b69f25a6d","name":"username","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["uid"],"is.mandatory.in.ldap":["true"],"read.only":["true"],"always.read.value.from.ldap":["false"],"user.model.attribute":["username"]}},{"id":"c762297e-8819-4140-9f04-f833526d2c44","name":"hmac-generated","providerId":"hmac-generated","providerType":"org.keycloak.keys.KeyProvider","parentId":"ci0-realm","config":{"priority":["100"],"algorithm":["HS256"]}},{"id":"374f64de-f25c-41ba-814b-2e9e3ca4c166","name":"Allowed
+        Client Scopes","providerId":"allowed-client-templates","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{"allow-default-scopes":["true"]}},{"id":"5389bc1d-9a46-42ef-bd18-f216ec561247","name":"Allowed
+        Client Scopes","providerId":"allowed-client-templates","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"authenticated","config":{"allow-default-scopes":["true"]}},{"id":"24a7c69a-9da6-4363-9eb0-6cea08e7774a","name":"username","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["uid"],"is.mandatory.in.ldap":["true"],"always.read.value.from.ldap":["false"],"read.only":["true"],"user.model.attribute":["username"]}},{"id":"779da1bc-e922-4e78-856e-9c5ed94aac12","name":"Full
+        Scope Disabled","providerId":"scope","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{}},{"id":"ecaeb5a2-1088-476c-bed4-e77db9c9294e","name":"creation
+        date","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["createTimestamp"],"is.mandatory.in.ldap":["false"],"read.only":["true"],"always.read.value.from.ldap":["true"],"user.model.attribute":["createTimestamp"]}},{"id":"d69762fb-559f-4081-aeab-f2a962749987","name":"creation
+        date","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["createTimestamp"],"is.mandatory.in.ldap":["false"],"always.read.value.from.ldap":["true"],"read.only":["true"],"user.model.attribute":["createTimestamp"]}},{"id":"e3622a21-06a7-489e-848c-ab924182539f","name":"modify
+        date","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["modifyTimestamp"],"is.mandatory.in.ldap":["false"],"read.only":["true"],"always.read.value.from.ldap":["true"],"user.model.attribute":["modifyTimestamp"]}},{"id":"75adbdc1-ae01-40c8-b42d-3a01df46bf63","name":"Consent
+        Required","providerId":"consent-required","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{}},{"id":"1e0f3101-ea63-4532-824d-ab7d147fba83","providerId":"declarative-user-profile","providerType":"org.keycloak.userprofile.UserProfileProvider","parentId":"ci0-realm","config":{}},{"id":"1b0cd013-1d3f-41e6-83e5-3575eac940da","name":"first
+        name","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["cn"],"is.mandatory.in.ldap":["true"],"always.read.value.from.ldap":["true"],"read.only":["true"],"user.model.attribute":["firstName"]}},{"id":"f17d07ac-bed8-4dd4-b853-89613e2283bd","name":"Trusted
+        Hosts","providerId":"trusted-hosts","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{"host-sending-registration-request-must-match":["true"],"client-uris-must-match":["true"]}},{"id":"9c620f8a-570b-440a-8d45-680999c03d59","name":"ci0-uf0-ldap","providerId":"ldap","providerType":"org.keycloak.storage.UserStorageProvider","parentId":"ci0-realm","config":{"fullSyncPeriod":["-1"],"pagination":["true"],"connectionPooling":["true"],"usersDn":["uid"],"cachePolicy":["DEFAULT"],"useKerberosForPasswordAuthentication":["false"],"importEnabled":["true"],"enabled":["true"],"changedSyncPeriod":["-1"],"bindCredential":["**********"],"usernameLDAPAttribute":["uid"],"bindDn":["admin"],"vendor":["rhds"],"uuidLDAPAttribute":["nsuniqueid"],"connectionUrl":["ldaps://172.17.0.4:636"],"allowKerberosAuthentication":["false"],"syncRegistrations":["false"],"authType":["simple"],"debug":["false"],"searchScope":["1"],"useTruststoreSpi":["ldapsOnly"],"trustEmail":["false"],"priority":["0"],"userObjectClasses":["inetOrgPerson,
+        organizationalPerson"],"rdnLDAPAttribute":["uid"],"validatePasswordPolicy":["false"],"batchSizeForSync":["1000"]}},{"id":"26a87f83-9e37-437f-8518-9d861d653fea","name":"Max
+        Clients Limit","providerId":"max-clients","providerType":"org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy","parentId":"ci0-realm","subType":"anonymous","config":{"max-clients":["200"]}},{"id":"1b288696-4456-4118-9c52-e837fda70364","name":"first
+        name","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["cn"],"is.mandatory.in.ldap":["true"],"read.only":["true"],"always.read.value.from.ldap":["true"],"user.model.attribute":["firstName"]}},{"id":"2ddcfd48-1000-4ff8-b613-8ba9acdf1981","name":"last
+        name","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"9c620f8a-570b-440a-8d45-680999c03d59","config":{"ldap.attribute":["sn"],"is.mandatory.in.ldap":["true"],"always.read.value.from.ldap":["true"],"read.only":["true"],"user.model.attribute":["lastName"]}},{"id":"d4464cea-d0fc-4ac2-b131-2df2e509364f","name":"last
+        name","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["sn"],"is.mandatory.in.ldap":["true"],"always.read.value.from.ldap":["true"],"read.only":["true"],"user.model.attribute":["lastName"]}},{"id":"48c4dbac-13dc-40bc-b4e8-2c14ad843415","name":"modify
+        date","providerId":"user-attribute-ldap-mapper","providerType":"org.keycloak.storage.ldap.mappers.LDAPStorageMapper","parentId":"7ce7affb-32eb-4a2e-937e-7de8fc606d36","config":{"ldap.attribute":["modifyTimestamp"],"is.mandatory.in.ldap":["false"],"read.only":["true"],"always.read.value.from.ldap":["true"],"user.model.attribute":["modifyTimestamp"]}},{"id":"972cfe4f-dc2d-451e-b5cb-ca2e28cc93e4","name":"rsa-generated","providerId":"rsa-generated","providerType":"org.keycloak.keys.KeyProvider","parentId":"ci0-realm","config":{"keyUse":["sig"],"priority":["100"]}}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '10465'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Nov 2022 13:05:44 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/unit/fetch/test_components.py
+++ b/tests/unit/fetch/test_components.py
@@ -1,0 +1,115 @@
+from operator import itemgetter
+
+from pytest import mark
+from pytest_unordered import unordered
+import json
+import os
+import shutil
+from kcfetcher.fetch import ComponentFetch
+from kcfetcher.store import Store
+from kcfetcher.utils import remove_folder, make_folder, login
+
+
+@mark.vcr()
+class TestComponentFetch:
+    def test_fetch(self):
+        datadir = "output/ci/outd"
+        remove_folder(datadir)
+        make_folder(datadir)
+        store_api = Store(datadir)
+        server = os.environ["SSO_API_URL"]
+        user = os.environ["SSO_API_USERNAME"]
+        password = os.environ["SSO_API_PASSWORD"]
+        kc = login(server, user, password)
+
+        realm_name = "ci0-realm"
+        resource_name = "components"
+        resource_identifier = "name"
+        obj = ComponentFetch(kc, resource_name, resource_identifier, realm_name)
+
+        obj.fetch(store_api)
+
+        # check generated content
+        print(os.listdir(datadir))
+        assert os.listdir(datadir) == unordered([
+            "last_name.json",
+            "consent_required.json",
+            "max_clients_limit.json",
+            "full_scope_disabled.json",
+            "modify_date.json",
+            "allowed_protocol_mapper_types.json",
+            "trusted_hosts.json",
+            "first_name.json",
+            "rsa-generated.json",
+            "username.json",
+            "ci0-uf0-ldap.json",
+            "aes-generated.json",
+            "rsa-enc-generated.json",
+            "creation_date.json",
+            "hmac-generated.json",
+            "allowed_client_scopes.json",
+            "ci0-uf1-ldap.json",
+        ])
+        return
+
+        assert os.listdir(os.path.join(datadir, "ci0-uf0-ldap")) == unordered(["ci0-uf0-ldap.json", "mappers"])
+        assert os.listdir(os.path.join(datadir, "ci0-uf0-ldap/mappers")) == unordered(["mappers.json"])
+        assert os.listdir(os.path.join(datadir, "ci0-uf1-ldap")) == unordered(["ci0-uf1-ldap.json", "mappers"])
+        assert os.listdir(os.path.join(datadir, "ci0-uf1-ldap/mappers")) == unordered(["mappers.json"])
+        #
+        data = json.load(open(os.path.join(datadir, "ci0-uf0-ldap/ci0-uf0-ldap.json")))
+        assert list(data.keys()) == [
+            'config',
+            'name',
+            'parentId',
+            'providerId',
+            'providerType',
+        ]
+        assert list(data["config"].keys()) == [
+            'allowKerberosAuthentication',
+            'authType',
+            'batchSizeForSync',
+            'bindCredential',
+            'bindDn',
+            'cachePolicy',
+            'changedSyncPeriod',
+            'connectionPooling',
+            'connectionUrl',
+            'debug',
+            'enabled',
+            'fullSyncPeriod',
+            'importEnabled',
+            'pagination',
+            'priority',
+            'rdnLDAPAttribute',
+            'searchScope',
+            'syncRegistrations',
+            'trustEmail',
+            'useKerberosForPasswordAuthentication',
+            'useTruststoreSpi',
+            'userObjectClasses',
+            'usernameLDAPAttribute',
+            'usersDn',
+            'uuidLDAPAttribute',
+            'validatePasswordPolicy',
+            'vendor',
+        ]
+        assert data["name"] == "ci0-uf0-ldap"
+        assert data["config"]["connectionUrl"] == ["ldaps://172.17.0.4:636"]
+
+        # check attribute mappers
+        data = json.load(open(os.path.join(datadir, "ci0-uf0-ldap/mappers/mappers.json")))
+        assert len(data) == 6
+        assert list(data[0].keys()) == [
+            'config',
+            'name',
+            'providerId',
+            'providerType',
+        ]
+        assert data[0]["providerId"] == "user-attribute-ldap-mapper"
+        assert data[0]["providerType"] == "org.keycloak.storage.ldap.mappers.LDAPStorageMapper"
+        assert len(data[0]["config"]) == 5
+        # sort by name, to have predictable order
+        data_sorted = sorted(data, key=itemgetter("name"))
+        assert data_sorted[1]["config"]["ldap.attribute"] == ["mail"]
+        assert data_sorted[1]["config"]["user.model.attribute"] == ["email"]

--- a/tests/unit/fetch/test_factory.py
+++ b/tests/unit/fetch/test_factory.py
@@ -2,21 +2,22 @@ from pytest import mark
 import json
 import os
 import shutil
-from kcfetcher.fetch import FetchFactory, CustomAuthenticationFetch, ClientFetch, GenericFetch
+from kcfetcher.fetch import FetchFactory, CustomAuthenticationFetch, ClientFetch, ComponentFetch, GenericFetch
 
 
 class TestFactory:
     @mark.parametrize(
-        "resource_name, expected_fetch_class",
+        "resource_name, resource_id, expected_fetch_class",
         [
-            ("components", GenericFetch),
-            ("authentication", CustomAuthenticationFetch),
-            ("clients", ClientFetch),
-            ("random-mock-resource-name", GenericFetch),
+            ("roles", "name", GenericFetch),
+            ("components", "name", ComponentFetch),
+            ("authentication", "alias", CustomAuthenticationFetch),
+            ("clients", "clientId", ClientFetch),
+            ("random-mock-resource-name", "name", GenericFetch),
         ]
     )
-    def test_create(self, resource_name, expected_fetch_class):
-        resource = [resource_name, "mock-resource-id"]
+    def test_create(self, resource_name, resource_id, expected_fetch_class):
+        resource = [resource_name, resource_id]
         factory = FetchFactory()
         client = factory.create(resource, "mock-kc", "mock-realm")
         assert isinstance(client, expected_fetch_class)

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -75,6 +75,28 @@ class Test_remove_ids:
         obj = remove_ids(kc_object)
         assert expected_obj == obj
 
+    @mark.parametrize(
+        "kc_object, expected_obj",
+        [
+            ({}, {}),
+            (
+                {"k1": "v1", "id": "id-v"},
+                {"k1": "v1"},
+            ),
+        ]
+    )
+    def test_returned_object_is_new(self, kc_object, expected_obj):
+        """
+        We often referr same object multipletimes.
+        Removing say "name" attribute needs to return a copy of object.
+        """
+        obj = remove_ids(kc_object)
+        assert expected_obj == obj
+        assert id(expected_obj) != id(obj)
+        # modify input, output must not change
+        obj.update({"new-key": "new-value"})
+        assert "new-key" not in expected_obj
+
 
 class Test_normalize:
     @mark.parametrize(


### PR DESCRIPTION
Rest API returns under /components an object with no name attribute.

Likely all components need to be moved to more specific subdirectories.
The PR just avoids crashing on this particular type of object, and logs warning that it was not saved to disk.