### PR TITLE
Remove container id from role

### DIFF
--- a/kcfetcher/fetch/client.py
+++ b/kcfetcher/fetch/client.py
@@ -39,6 +39,10 @@ class ClientFetch(GenericFetch):
             client_id = kc_object['id']
             client_roles_api = self.kc.build(f"clients/{client_id}/roles", realm)
             for role in roles:
+                # the containerId needs to be removed, it is client clientID (UUID)
+                assert role["containerId"] == client_id
+                role.pop("containerId")
+
                 if not role["composite"]:
                     continue
                 composites = client_roles_api.get(f"{role['name']}/composites").verify().resp().json()

--- a/tests/unit/fetch/test_client.py
+++ b/tests/unit/fetch/test_client.py
@@ -76,7 +76,9 @@ class TestClientFetch_vcr:
             'attributes',
             'clientRole',
             'composite',
-            'containerId',
+            # containerId UUID - clientId, it MUST be removed.
+            # The parent client clientId will be derived from roles.json filepath.
+            # 'containerId',
             'description',
             'name',
         ]
@@ -92,7 +94,7 @@ class TestClientFetch_vcr:
             'clientRole',
             'composite',
             'composites',
-            'containerId',
+            # 'containerId',
             'description',
             'name',
         ]


### PR DESCRIPTION
containerId is UUID - client.clientID. What we need saved to disk if client.alias (the name), not UUID. Client alias can be derived from roles.json filepath  