### PR TITLE
Error out if Identy Provider is not SAML

### DIFF
--- a/kcfetcher/fetch/__init__.py
+++ b/kcfetcher/fetch/__init__.py
@@ -5,6 +5,7 @@ from .custom_authentication import CustomAuthenticationFetch
 from .user import UserFetch
 from .user_federation import UserFederationFetch
 from .component import ComponentFetch
+from .identity_provider import IdentityProviderFetch
 from .factory import FetchFactory
 
 __all__ = [

--- a/kcfetcher/fetch/factory.py
+++ b/kcfetcher/fetch/factory.py
@@ -1,5 +1,5 @@
 from kcfetcher.fetch import CustomAuthenticationFetch, ClientFetch, GenericFetch, UserFetch, ClientScopeFetch,\
-    UserFederationFetch, ComponentFetch
+    UserFederationFetch, ComponentFetch, IdentityProviderFetch
 
 
 class FetchFactory:
@@ -10,6 +10,7 @@ class FetchFactory:
             'client-scopes': ClientScopeFetch,
             'users': UserFetch,
             'user-federations': UserFederationFetch,
+            'identity-provider': IdentityProviderFetch,
             'components': ComponentFetch,
         }
 

--- a/kcfetcher/fetch/identity_provider.py
+++ b/kcfetcher/fetch/identity_provider.py
@@ -1,11 +1,24 @@
+import logging
+import sys
 from kcfetcher.fetch import GenericFetch
+
+logger = logging.getLogger(__name__)
 
 
 class IdentityProviderFetch(GenericFetch):
     def _get_data(self):
         kc = self.kc.build(self.resource_name, self.realm)
         kc_objects = self.all(kc)
-        # remove internalId
+
         for kc_object in kc_objects:
+            # remove internalId
             kc_object.pop("internalId")
+
+            # Show error if provider type is not SAML.
+            # Also openid v1 seems to work, but we didn't check all attributes.
+            tested_provider_ids = ["saml"]
+            if kc_object['providerId'] not in tested_provider_ids:
+                logger.error(f"Identity provider providerId={kc_object['providerId']} is not sufficiently tested, realm={self.realm} alias={kc_object['alias']}")
+                sys.exit(1)
+
         return kc_objects

--- a/kcfetcher/fetch/identity_provider.py
+++ b/kcfetcher/fetch/identity_provider.py
@@ -1,0 +1,11 @@
+from kcfetcher.fetch import GenericFetch
+
+
+class IdentityProviderFetch(GenericFetch):
+    def _get_data(self):
+        kc = self.kc.build(self.resource_name, self.realm)
+        kc_objects = self.all(kc)
+        # remove internalId
+        for kc_object in kc_objects:
+            kc_object.pop("internalId")
+        return kc_objects

--- a/tests/unit/fetch/cassettes/TestIdentityProviderFetch.test_fetch.yaml
+++ b/tests/unit/fetch/cassettes/TestIdentityProviderFetch.test_fetch.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/realms/master/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"issuer":"https://172.17.0.2:8443/auth/realms/master","authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth","token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","end_session_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/logout","jwks_uri":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/certs","check_session_iframe":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba"],"response_types_supported":["code","none","id_token","token","id_token
+        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","address","offline_access","phone","email","microprofile-jwt","roles","web-origins","profile"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
+    headers:
+      Cache-Control:
+      - no-cache, must-revalidate, no-transform, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5646'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 14 Nov 2022 22:07:04 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: client_id=admin-cli&grant_type=password&realm=master&username=admin&password=admin
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
+  response:
+    body:
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjM2ODQsImlhdCI6MTY2ODQ2MzYyNCwianRpIjoiYTU5Y2U4MTktMDhkMS00NGQzLTgzNWMtNWVmMWQ1ZDlmZThjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjhlZDEzZjcxLThlOWEtNDYyOS1hOTNjLTMzMWNiMTA3MWI1YiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI4ZWQxM2Y3MS04ZTlhLTQ2MjktYTkzYy0zMzFjYjEwNzFiNWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.Qs4eN11iMTiLgLTd8n-vcctUXlsnjRn0e9-TpDSJyxSOjE6q1LkE7IKTXF--fhrWY49mzXfSPqMAfsW5zx1Op-THRSmFg43CrEvrywwRWTjrIENpd_dNceAJqygHH5S4mZqTgloOPj4TNx1u9MsRxebL7ZCHAzfzOOv4G9PTWEkYn_OiIogARftEwZXz1Yes2hvDJgfGEe5a14Ma4w0Thm1BaDGVONWBGafnaYRq7Yo-LqR5QW0WRw8zPLUW5pVXEn26WjjSqjJk9mnIgP5PgIUFjC-rD0LTLEhsqi-ERgFMLk4mpdgwqvP90kNanL02griFQmKs-Kmw3aZSKVGDVw","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxYmVjOGRiNS1mYWEwLTQ3NTEtOTdlOC04YzA1MjdjYzMyYTgifQ.eyJleHAiOjE2Njg0NjU0MjQsImlhdCI6MTY2ODQ2MzYyNCwianRpIjoiODU3MWI3M2ItMGEzYy00M2E5LWE2YmItMjkwOWJmZWZkMTcxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI4ZWQxM2Y3MS04ZTlhLTQ2MjktYTkzYy0zMzFjYjEwNzFiNWIiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI4ZWQxM2Y3MS04ZTlhLTQ2MjktYTkzYy0zMzFjYjEwNzFiNWIifQ.boDDcAs0cx_bA0DOKfa1Ka9y8jcp9zLhwfzwUte6KZg","token_type":"Bearer","not-before-policy":0,"session_state":"8ed13f71-8e9a-4629-a93c-331cb1071b5b","scope":"email
+        profile"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1846'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 14 Nov 2022 22:07:04 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Set-Cookie:
+      - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
+        00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
+      - KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
+        Path=/auth/realms/master/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjM2ODQsImlhdCI6MTY2ODQ2MzYyNCwianRpIjoiYTU5Y2U4MTktMDhkMS00NGQzLTgzNWMtNWVmMWQ1ZDlmZThjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjhlZDEzZjcxLThlOWEtNDYyOS1hOTNjLTMzMWNiMTA3MWI1YiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI4ZWQxM2Y3MS04ZTlhLTQ2MjktYTkzYy0zMzFjYjEwNzFiNWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.Qs4eN11iMTiLgLTd8n-vcctUXlsnjRn0e9-TpDSJyxSOjE6q1LkE7IKTXF--fhrWY49mzXfSPqMAfsW5zx1Op-THRSmFg43CrEvrywwRWTjrIENpd_dNceAJqygHH5S4mZqTgloOPj4TNx1u9MsRxebL7ZCHAzfzOOv4G9PTWEkYn_OiIogARftEwZXz1Yes2hvDJgfGEe5a14Ma4w0Thm1BaDGVONWBGafnaYRq7Yo-LqR5QW0WRw8zPLUW5pVXEn26WjjSqjJk9mnIgP5PgIUFjC-rD0LTLEhsqi-ERgFMLk4mpdgwqvP90kNanL02griFQmKs-Kmw3aZSKVGDVw
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/identity-provider/instances
+  response:
+    body:
+      string: '[{"alias":"ci0-idp-saml-0","displayName":"ci0-idp-saml-0-displayName","internalId":"ee34d6c3-a994-4135-a906-20d1c50bcc57","providerId":"saml","enabled":true,"updateProfileFirstLoginMode":"on","trustEmail":false,"storeToken":false,"addReadTokenRoleOnCreate":false,"authenticateByDefault":false,"linkOnly":false,"firstBrokerLoginFlowAlias":"first
+        broker login","config":{"authnContextClassRefs":"[\"aa\",\"bb\"]","nameIDPolicyFormat":"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent","singleLogoutServiceUrl":"https://172.17.0.6:8443/logout","authnContextDeclRefs":"[\"cc\",\"dd\"]","entityId":"https://172.17.0.2:8443/auth/realms/ci0-realm","signatureAlgorithm":"RSA_SHA256","wantAssertionsEncrypted":"true","xmlSigKeyInfoKeyNameTransformer":"KEY_ID","useJwksUrl":"true","allowCreate":"true","authnContextComparisonType":"exact","syncMode":"IMPORT","singleSignOnServiceUrl":"https://172.17.0.6:8443/signon","principalType":"SUBJECT"}}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '939'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 14 Nov 2022 22:07:04 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/unit/fetch/test_identity_provider.py
+++ b/tests/unit/fetch/test_identity_provider.py
@@ -1,0 +1,68 @@
+from operator import itemgetter
+
+from pytest import mark
+from pytest_unordered import unordered
+import json
+import os
+import shutil
+from kcfetcher.fetch import IdentityProviderFetch
+from kcfetcher.store import Store
+from kcfetcher.utils import remove_folder, make_folder, login
+
+
+@mark.vcr()
+class TestIdentityProviderFetch:
+    def test_fetch(self):
+        datadir = "output/ci/outd"
+        remove_folder(datadir)
+        make_folder(datadir)
+        store_api = Store(datadir)
+        server = os.environ["SSO_API_URL"]
+        user = os.environ["SSO_API_USERNAME"]
+        password = os.environ["SSO_API_PASSWORD"]
+        kc = login(server, user, password)
+
+        realm_name = "ci0-realm"
+        resource_name = "identity-provider"
+        resource_identifier = "alias"
+        obj = IdentityProviderFetch(kc, resource_name, resource_identifier, realm_name)
+
+        obj.fetch(store_api)
+
+        # check generated content
+        assert os.listdir(datadir) == unordered(["ci0-idp-saml-0.json"])
+        #
+        data = json.load(open(os.path.join(datadir, "ci0-idp-saml-0.json")))
+        assert list(data.keys()) == [
+            'addReadTokenRoleOnCreate',
+            'alias',
+            'authenticateByDefault',
+            'config',
+            'displayName',
+            'enabled',
+            'firstBrokerLoginFlowAlias',
+            # 'internalId',
+            'linkOnly',
+            'providerId',
+            'storeToken',
+            'trustEmail',
+            'updateProfileFirstLoginMode',
+        ]
+        assert list(data["config"].keys()) == [
+            'allowCreate',
+            'authnContextClassRefs',
+            'authnContextComparisonType',
+            'authnContextDeclRefs',
+            'entityId',
+            'nameIDPolicyFormat',
+            'principalType',
+            'signatureAlgorithm',
+            'singleLogoutServiceUrl',
+            'singleSignOnServiceUrl',
+            'syncMode',
+            'useJwksUrl',
+            'wantAssertionsEncrypted',
+            'xmlSigKeyInfoKeyNameTransformer',
+        ]
+        assert data["alias"] == "ci0-idp-saml-0"
+        assert data["config"]["entityId"] == "https://172.17.0.2:8443/auth/realms/ci0-realm"


### PR DESCRIPTION
Only SAML identity provider type was really tested. It is safer to fail with error, and not assume OpenID and predefined social provides work.

The iinternalID attribute is removed from json file - it is UUID. And integration/unit test was added, somehow we had code, but no test - by bad.