### PR TITLE
Realm roles - export attributes and composite sub-roles

### DIFF
--- a/.github/inject_data.py
+++ b/.github/inject_data.py
@@ -55,10 +55,12 @@ def main():
     client1_role0_name = "ci0-client1-role0"
     idp_alias = "ci0-idp-saml-0"
     ci0_role0_name = "ci0-role-0"
+    ci0_role1_name = "ci0-role-1"
     ci0_role1a_name = "ci0-role-1a"
     ci0_role1b_name = "ci0-role-1b"
     role_names_plain = [
         ci0_role0_name,
+        ci0_role1_name,
         ci0_role1a_name,
         ci0_role1b_name,
     ]
@@ -232,10 +234,13 @@ def main():
                 "attributes": {role_name + "-key0": [role_name + "-value0"]},
             }).isOk()
     ci0_role0 = roles_api.findFirst({'key': 'name', 'value': ci0_role0_name})
+    ci0_role1 = roles_api.findFirst({'key': 'name', 'value': ci0_role1_name})
     ci0_role1a = roles_api.findFirst({'key': 'name', 'value': ci0_role1a_name})
     ci0_role1b = roles_api.findFirst({'key': 'name', 'value': ci0_role1b_name})
 
-    # TODO create composite roles
+    # Create composite realm role
+    role_composite_api = kc.build(f"/roles/{ci0_role1_name}/composites", realm_name)
+    role_composite_api.create([ci0_role1a, ci0_role1b, client0_role1a])
     # for role_name in role_names_composite:
     #     if not roles_api.findFirst({'key': 'name', 'value': role_name}):
     #         roles_api.create({

--- a/kcfetcher/fetch/__init__.py
+++ b/kcfetcher/fetch/__init__.py
@@ -6,6 +6,7 @@ from .user import UserFetch
 from .user_federation import UserFederationFetch
 from .component import ComponentFetch
 from .identity_provider import IdentityProviderFetch
+from .role import RoleFetch
 from .factory import FetchFactory
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     ClientScopeFetch,
     CustomAuthenticationFetch,
     UserFetch,
+    RoleFetch,
     FetchFactory,
 ]

--- a/kcfetcher/fetch/client.py
+++ b/kcfetcher/fetch/client.py
@@ -69,7 +69,7 @@ class ClientFetch(GenericFetch):
                 role["composites"] = [minimize_role_representation(cc, kc_objects) for cc in composites]
 
             store_api.add_child('roles')  # clients/<client_ind>/roles
-            store_api.store_one_with_alias('roles', roles)
+            store_api.store(roles, "name")
             store_api.remove_last_child()  # clients/<client_ind>/roles
 
             # Compute scope-mappings

--- a/kcfetcher/fetch/client.py
+++ b/kcfetcher/fetch/client.py
@@ -1,6 +1,7 @@
 from kcapi.rest.crud import KeycloakCRUD
 
 from kcfetcher.fetch import GenericFetch
+from kcfetcher.fetch.role import RoleFetch
 from kcfetcher.utils import find_in_list, minimize_role_representation
 
 
@@ -24,6 +25,7 @@ class ClientFetch(GenericFetch):
         counter = 0
         client_id_all = [client["id"] for client in kc_objects]
         for kc_object in kc_objects:
+            client_id = kc_object['id']
             store_api.add_child('client-' + str(counter))  # clients/<client_ind>
             # authenticationFlowBindingOverrides need to be saved with auth flow alias/name, not id/UUID
             for auth_flow_override in kc_object["authenticationFlowBindingOverrides"]:
@@ -32,44 +34,9 @@ class ClientFetch(GenericFetch):
                 kc_object["authenticationFlowBindingOverrides"][auth_flow_override] = auth_flow_alias
             store_api.store_one(kc_object, identifier)
 
-            client_query = {'key': 'clientId', 'value': kc_object['clientId']}
-            # GET /{realm}/clients/{id}/roles - briefRepresentation=True is default
-            # We get full RoleRepresentation from
-            #   GET /{realm}/clients/{id}/roles/{role-name} or
-            #   GET /{realm}/roles-by-id/{role-id}
-            # RoleRepresentation includes .attributes attribute.
-            roles_brief = clients_api.roles(client_query).all()
-            roles_by_id_api = self.kc.build("roles-by-id", realm)
-            roles = [
-                roles_by_id_api.get(role_brief['id']).verify().resp().json()
-                for role_brief in roles_brief
-            ]
-            # But composites are missing :/.
-            # Get them from GET /{realm}/clients/{id}/roles/{role-name}/composites.
-            client_id = kc_object['id']
-            client_roles_api = self.kc.build(f"clients/{client_id}/roles", realm)
-            for role in roles:
-                # the containerId needs to be removed, it is client clientID (UUID)
-                assert role["containerId"] == client_id
-                role.pop("containerId")
-
-                if not role["composite"]:
-                    continue
-                composites = client_roles_api.get(f"{role['name']}/composites").verify().resp().json()
-
-                if 0:
-                    # Those two are same. Are they nicer the code above?
-                    client_role_composites_api = clients_api.roles(client_query).get_child(clients_api, f"{client_id}/roles/{role['name']}", "composites")
-                    client_role_composites_api = KeycloakCRUD.get_child(clients_api, f"{client_id}/roles/{role['name']}", "composites")
-                    x = client_role_composites_api.get(_id=None).verify().resp().json()
-
-                # Now add composites into role dict
-                # For client role, we need to replace containerId (UUID) with client.clientId (string)
-                assert "composites" not in role
-                role["composites"] = [minimize_role_representation(cc, kc_objects) for cc in composites]
-
+            role_fetcher = RoleFetch(self.kc, f"clients/{client_id}/roles", "name", self.realm)
             store_api.add_child('roles')  # clients/<client_ind>/roles
-            store_api.store(roles, "name")
+            role_fetcher.fetch(store_api)
             store_api.remove_last_child()  # clients/<client_ind>/roles
 
             # Compute scope-mappings

--- a/kcfetcher/fetch/client.py
+++ b/kcfetcher/fetch/client.py
@@ -1,28 +1,7 @@
 from kcapi.rest.crud import KeycloakCRUD
 
 from kcfetcher.fetch import GenericFetch
-from kcfetcher.utils import find_in_list
-
-def minimize_role_representation(full_role, clients):
-    """
-    This is used to get a minimal role representation.
-    It contains just enough data that sub-role of the composite role can be found.
-    Or that role referred by client scope mapping can be found.
-
-    For client roles we replace attribute containerId with containerName, value is set to client.clientId.
-    For realm roles, containerId already contains realm name, so attribute is just renamed.
-
-    Complete role representation is stored in realm /roles or client/roles/.
-    """
-    containerId = full_role["containerId"]
-    container_name = containerId
-    if full_role["clientRole"]:
-        container_name = find_in_list(clients, id=containerId)["clientId"]
-    return dict(
-        name=full_role["name"],
-        clientRole=full_role["clientRole"],
-        containerName=container_name,
-    )
+from kcfetcher.utils import find_in_list, minimize_role_representation
 
 
 class ClientFetch(GenericFetch):

--- a/kcfetcher/fetch/factory.py
+++ b/kcfetcher/fetch/factory.py
@@ -1,5 +1,5 @@
 from kcfetcher.fetch import CustomAuthenticationFetch, ClientFetch, GenericFetch, UserFetch, ClientScopeFetch,\
-    UserFederationFetch, ComponentFetch, IdentityProviderFetch
+    UserFederationFetch, ComponentFetch, IdentityProviderFetch, RoleFetch
 
 
 class FetchFactory:
@@ -11,6 +11,7 @@ class FetchFactory:
             'users': UserFetch,
             'user-federations': UserFederationFetch,
             'identity-provider': IdentityProviderFetch,
+            'roles': RoleFetch,
             'components': ComponentFetch,
         }
 

--- a/kcfetcher/fetch/role.py
+++ b/kcfetcher/fetch/role.py
@@ -1,0 +1,28 @@
+import logging
+from kcfetcher.fetch import GenericFetch
+
+logger = logging.getLogger(__name__)
+
+
+# A realm role
+class RoleFetch(GenericFetch):
+    def __init__(self, kc, resource_name, resource_id="", realm=""):
+        super().__init__(kc, resource_name, resource_id, realm)
+        assert "roles" == self.resource_name
+        assert "name" == self.id
+
+    def _get_data(self):
+        roles_api = self.kc.build(self.resource_name, self.realm)
+        brief_roles = self.all(roles_api)
+        # But we used GET /{realm}/roles - it missed .attributes attribute (it is briefRepresentation).
+        # We get full role representation from GET /{realm}/roles-by-id/{role-id}
+        roles_by_id_api = self.kc.build("roles-by-id", self.realm)
+        roles = []
+        for brief_role in brief_roles:
+            role = roles_by_id_api.get(brief_role["id"]).verify().resp().json()
+            roles.append(role)
+
+        return roles
+
+    def all(self, kc):
+        return list(filter(lambda fn: not fn[self.id] in self.black_list, kc.all()))

--- a/kcfetcher/fetch/role.py
+++ b/kcfetcher/fetch/role.py
@@ -1,4 +1,6 @@
 import logging
+
+from kcfetcher.utils import minimize_role_representation
 from kcfetcher.fetch import GenericFetch
 
 logger = logging.getLogger(__name__)
@@ -17,15 +19,24 @@ class RoleFetch(GenericFetch):
         # But we used GET /{realm}/roles - it missed .attributes attribute (it is briefRepresentation).
         # We get full role representation from GET /{realm}/roles-by-id/{role-id}
         roles_by_id_api = self.kc.build("roles-by-id", self.realm)
+        clients_api = self.kc.build("clients", self.realm)
+        clients = self.all(clients_api)
         roles = []
         for brief_role in brief_roles:
-            role = roles_by_id_api.get(brief_role["id"]).verify().resp().json()
+            role_id = brief_role["id"]
+            role = roles_by_id_api.get(role_id).verify().resp().json()
+
             # the containerId needs to be removed, it is UUID (clientID for client roles, realm name for realm roles)
             assert role["containerId"] == self.realm
             role.pop("containerId")
+
+            if role["composite"]:
+                # Now add composites into role dict
+                # For client role, we need to replace containerId (UUID) with client.clientId (string)
+                assert "composites" not in role
+                composites = roles_by_id_api.get(f"{role_id}/composites").verify().resp().json()
+                role["composites"] = [minimize_role_representation(cc, clients) for cc in composites]
+
             roles.append(role)
 
         return roles
-
-    def all(self, kc):
-        return list(filter(lambda fn: not fn[self.id] in self.black_list, kc.all()))

--- a/kcfetcher/fetch/role.py
+++ b/kcfetcher/fetch/role.py
@@ -10,8 +10,18 @@ logger = logging.getLogger(__name__)
 class RoleFetch(GenericFetch):
     def __init__(self, kc, resource_name, resource_id="", realm=""):
         super().__init__(kc, resource_name, resource_id, realm)
-        assert "roles" == self.resource_name
         assert "name" == self.id
+
+        # assert self.resource_name in ["roles", "clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/roles"]
+        if self.resource_name == "roles":
+            # fetching realm roles
+            pass
+        else:
+            # fetching client roles, client by client
+            assert len(self.resource_name) == 50
+            assert len(self.resource_name.split("/")) == 3
+            assert self.resource_name.split("/")[0] == "clients"
+            assert self.resource_name.split("/")[2] == "roles"
 
     def _get_data(self):
         roles_api = self.kc.build(self.resource_name, self.realm)
@@ -27,7 +37,11 @@ class RoleFetch(GenericFetch):
             role = roles_by_id_api.get(role_id).verify().resp().json()
 
             # the containerId needs to be removed, it is UUID (clientID for client roles, realm name for realm roles)
-            assert role["containerId"] == self.realm
+            if role['clientRole']:
+                # must be parent client UUID, check the length
+                assert len(role["containerId"]) == 36
+            else:
+                assert role["containerId"] == self.realm
             role.pop("containerId")
 
             if role["composite"]:

--- a/kcfetcher/fetch/role.py
+++ b/kcfetcher/fetch/role.py
@@ -20,6 +20,9 @@ class RoleFetch(GenericFetch):
         roles = []
         for brief_role in brief_roles:
             role = roles_by_id_api.get(brief_role["id"]).verify().resp().json()
+            # the containerId needs to be removed, it is UUID (clientID for client roles, realm name for realm roles)
+            assert role["containerId"] == self.realm
+            role.pop("containerId")
             roles.append(role)
 
         return roles

--- a/kcfetcher/utils/__init__.py
+++ b/kcfetcher/utils/__init__.py
@@ -1,4 +1,4 @@
-from .helper import remove_folder, make_folder, remove_ids, normalize, login, find_in_list
+from .helper import remove_folder, make_folder, remove_ids, normalize, login, find_in_list, minimize_role_representation
 
 __all__ = [
     remove_folder,
@@ -7,4 +7,5 @@ __all__ = [
     normalize,
     login,
     find_in_list,
+    minimize_role_representation,
 ]

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -13,6 +13,27 @@ def find_in_list(objects, **kwargs):
         if key in obj and obj[key] == value:
             return obj
 
+def minimize_role_representation(full_role, clients):
+    """
+    This is used to get a minimal role representation.
+    It contains just enough data that sub-role of the composite role can be found.
+    Or that role referred by client scope mapping can be found.
+
+    For client roles we replace attribute containerId with containerName, value is set to client.clientId.
+    For realm roles, containerId already contains realm name, so attribute is just renamed.
+
+    Complete role representation is stored in realm /roles or client/roles/.
+    """
+    containerId = full_role["containerId"]
+    container_name = containerId
+    if full_role["clientRole"]:
+        container_name = find_in_list(clients, id=containerId)["clientId"]
+    return dict(
+        name=full_role["name"],
+        clientRole=full_role["clientRole"],
+        containerName=container_name,
+    )
+
 
 def remove_ids(kc_object={}):
     # simple scalar values are safe to return

--- a/tests/unit/fetch/cassettes/TestClientFetch_vcr.test_fetch.yaml
+++ b/tests/unit/fetch/cassettes/TestClientFetch_vcr.test_fetch.yaml
@@ -15,7 +15,7 @@ interactions:
   response:
     body:
       string: '{"issuer":"https://172.17.0.2:8443/auth/realms/master","authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth","token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","end_session_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/logout","jwks_uri":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/certs","check_session_iframe":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba"],"response_types_supported":["code","none","id_token","token","id_token
-        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","address","offline_access","phone","email","microprofile-jwt","roles","web-origins","profile"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
+        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","phone","profile","offline_access","microprofile-jwt","address","email","web-origins","roles"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
     headers:
       Cache-Control:
       - no-cache, must-revalidate, no-transform, no-store
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -59,8 +59,8 @@ interactions:
     uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxYmVjOGRiNS1mYWEwLTQ3NTEtOTdlOC04YzA1MjdjYzMyYTgifQ.eyJleHAiOjE2Njg0NjMyOTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiMGM2OWRiYmEtOWY2Mi00ZWU3LWJjZTctMjI0OTdhY2NmOWU0IiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQifQ.-oBMK45oZVvG6UDcR0KmJxbeoYICNGUv45d2H9spWqc","token_type":"Bearer","not-before-policy":0,"session_state":"05b7c27c-9137-491e-9b21-7a0718a8a72d","scope":"email
-        profile"}'
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzMjRiMjljYy0yYmQxLTRlMGItYmMwOC0yM2NhZmQzMzEyNzUifQ.eyJleHAiOjE2Njg1MzI1MDgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiOTFjMGYzYjUtNDlkYy00MGU3LTlmMTItMWExMjlkZGMyYTZiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMifQ.5d9DO3bUcKlAdYuJAofpsLnmL5hWgkXtchDyBMFrA6k","token_type":"Bearer","not-before-policy":0,"session_state":"62e11ebf-9aad-48d9-bdac-aba18ff33813","scope":"profile
+        email"}'
     headers:
       Cache-Control:
       - no-store
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -100,7 +100,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -111,8 +111,8 @@ interactions:
     uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients
   response:
     body:
-      string: '[{"id":"911d746e-55fb-4f4d-a006-1d1c8b4aaf6c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1b1c9d0e-f7f1-4f9b-8c37-c2a6b6f8d618","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"9c630e3d-0fbb-436b-b1b8-d9cd3b14d5c9","name":"audience
-        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"98b41d79-2ed0-42ec-8fe9-603d6cf0e551","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2ba411a3-ba1c-43ce-8f93-9842262004c4","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"c693d31d-c4ca-4fd7-9981-fa480905573f"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2d9e32dd-a26e-4baa-97ef-a36a3ebd13b6","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"ac88ad0e-e314-43fb-83e0-d676ba6d98cd","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"8a7ef691-a370-4a39-bd9d-cb016ebb79c4","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
+      string: '[{"id":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"7361940f-7d92-494a-8d76-532de091f940","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"69e7e632-f5dd-4ae0-bac5-b0e6e3cad929","name":"audience
+        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2da8e6c8-a57b-48b6-bd5e-db632529e920","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"92d68ae6-c1df-4f71-8e81-da09def6a279","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"81c9e6d8-0249-423d-bd43-6d61b0254eda","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"42702a64-a67e-46c9-ba0f-628cdef45045"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"5b05d663-6523-428a-8e2d-ecbb2c686182","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"d1091426-cb88-4bc3-9403-d919f2abd31d","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"6569f3a8-de45-42d5-9be7-e7c8fec20301","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"1a4270bf-7cfd-4327-a339-22e9f1baf205","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
     headers:
       Cache-Control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -145,7 +145,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -156,21 +156,21 @@ interactions:
     uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/authentication/flows
   response:
     body:
-      string: '[{"id":"c693d31d-c4ca-4fd7-9981-fa480905573f","alias":"browser","description":"browser
-        based authentication","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"auth-cookie","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"auth-spnego","authenticatorFlow":false,"requirement":"DISABLED","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"identity-provider-redirector","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":25,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"ALTERNATIVE","priority":30,"flowAlias":"forms","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"e56d9ffe-456b-4678-9d5d-1b81922ab1f3","alias":"direct
+      string: '[{"id":"42702a64-a67e-46c9-ba0f-628cdef45045","alias":"browser","description":"browser
+        based authentication","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"auth-cookie","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"auth-spnego","authenticatorFlow":false,"requirement":"DISABLED","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"identity-provider-redirector","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":25,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"ALTERNATIVE","priority":30,"flowAlias":"forms","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"b8541495-671e-4c04-846a-db28d1105975","alias":"direct
         grant","description":"OpenID Connect Resource Owner Grant","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"direct-grant-validate-username","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"direct-grant-validate-password","authenticatorFlow":false,"requirement":"REQUIRED","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"CONDITIONAL","priority":30,"flowAlias":"Direct
-        Grant - Conditional OTP","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"ec1c7d4e-639e-493f-a167-c2f4bfaafb34","alias":"registration","description":"registration
+        Grant - Conditional OTP","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"1c748bbd-7fd0-42f6-87bf-5de11a68344a","alias":"registration","description":"registration
         flow","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"registration-page-form","authenticatorFlow":true,"requirement":"REQUIRED","priority":10,"flowAlias":"registration
-        form","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"64672783-cd30-43be-a701-a210262d8bf9","alias":"reset
+        form","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"8df8ba13-4458-4b36-8a78-72ff8e46824e","alias":"reset
         credentials","description":"Reset credentials for a user if they forgot their
         password or something","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"reset-credentials-choose-user","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"reset-credential-email","authenticatorFlow":false,"requirement":"REQUIRED","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"reset-password","authenticatorFlow":false,"requirement":"REQUIRED","priority":30,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"CONDITIONAL","priority":40,"flowAlias":"Reset
-        - Conditional OTP","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"720f3c45-9d6a-43d8-8fff-98394b201d96","alias":"clients","description":"Base
-        authentication for clients","providerId":"client-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"client-secret","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-jwt","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-secret-jwt","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":30,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-x509","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":40,"userSetupAllowed":false,"autheticatorFlow":false}]},{"id":"d6fef452-096c-4089-9186-0bdb7150cedf","alias":"first
+        - Conditional OTP","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"b661bbbb-2000-46db-abd9-533c927166e4","alias":"clients","description":"Base
+        authentication for clients","providerId":"client-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"client-secret","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-jwt","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":20,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-secret-jwt","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":30,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticator":"client-x509","authenticatorFlow":false,"requirement":"ALTERNATIVE","priority":40,"userSetupAllowed":false,"autheticatorFlow":false}]},{"id":"5d2a8925-acfa-4e6b-8423-3795e1890609","alias":"first
         broker login","description":"Actions taken after first broker login with identity
         provider account, which is not yet linked to any Keycloak account","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticatorConfig":"review
         profile config","authenticator":"idp-review-profile","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"REQUIRED","priority":20,"flowAlias":"User
-        creation or linking","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"a5f55724-09a6-482d-b934-29468ac0d69e","alias":"docker
-        auth","description":"Used by Docker clients to authenticate against the IDP","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"docker-http-basic-authenticator","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false}]},{"id":"74740d83-adbe-47ff-80ae-7b15edd6d63f","alias":"http
+        creation or linking","userSetupAllowed":false,"autheticatorFlow":true}]},{"id":"e81686f2-7a08-464b-8c1e-b44bda579f6d","alias":"docker
+        auth","description":"Used by Docker clients to authenticate against the IDP","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"docker-http-basic-authenticator","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false}]},{"id":"ec7a77f6-69cf-4d28-8c22-9e1fe33724f6","alias":"http
         challenge","description":"An authentication flow based on challenge-response
         HTTP Authentication Schemes","providerId":"basic-flow","topLevel":true,"builtIn":true,"authenticationExecutions":[{"authenticator":"no-cookie-redirect","authenticatorFlow":false,"requirement":"REQUIRED","priority":10,"userSetupAllowed":false,"autheticatorFlow":false},{"authenticatorFlow":true,"requirement":"REQUIRED","priority":20,"flowAlias":"Authentication
         Options","userSetupAllowed":false,"autheticatorFlow":true}]}]'
@@ -184,7 +184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -206,7 +206,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -214,55 +214,10 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda/roles
   response:
     body:
-      string: '[{"id":"911d746e-55fb-4f4d-a006-1d1c8b4aaf6c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1b1c9d0e-f7f1-4f9b-8c37-c2a6b6f8d618","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"9c630e3d-0fbb-436b-b1b8-d9cd3b14d5c9","name":"audience
-        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"98b41d79-2ed0-42ec-8fe9-603d6cf0e551","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2ba411a3-ba1c-43ce-8f93-9842262004c4","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"c693d31d-c4ca-4fd7-9981-fa480905573f"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2d9e32dd-a26e-4baa-97ef-a36a3ebd13b6","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"ac88ad0e-e314-43fb-83e0-d676ba6d98cd","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"8a7ef691-a370-4a39-bd9d-cb016ebb79c4","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '8644'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/roles
-  response:
-    body:
-      string: '[{"id":"f0470475-938b-4359-a575-2e9f68e255f3","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"},{"id":"66adc5f5-9cf8-454c-8907-9eb18594c923","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"},{"id":"51087d42-6a13-46db-8eaa-5c65946cba54","name":"ci0-client0-role1","description":"ci0-client0-role1-desc","composite":true,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"},{"id":"68ae87c4-e467-441b-82f5-6cff9dc478de","name":"ci0-client0-role0","description":"ci0-client0-role0-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"}]'
+      string: '[{"id":"daab7ee6-94d8-43fa-ac30-da4935e1a420","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"},{"id":"0caa8580-16e9-4610-a7fc-47fc9f91c6cc","name":"ci0-client0-role1","description":"ci0-client0-role1-desc","composite":true,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"},{"id":"7e233ead-9628-4b26-9af3-26dddf42a673","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"},{"id":"12a3d7f2-cb89-471d-9cb9-5c5497415fe6","name":"ci0-client0-role0","description":"ci0-client0-role0-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"}]'
     headers:
       Cache-Control:
       - no-cache
@@ -273,7 +228,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -295,359 +250,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/f0470475-938b-4359-a575-2e9f68e255f3
-  response:
-    body:
-      string: '{"id":"f0470475-938b-4359-a575-2e9f68e255f3","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","attributes":{"ci0-client0-role1b-key0":["ci0-client0-role1b-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '273'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/66adc5f5-9cf8-454c-8907-9eb18594c923
-  response:
-    body:
-      string: '{"id":"66adc5f5-9cf8-454c-8907-9eb18594c923","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","attributes":{"ci0-client0-role1a-key0":["ci0-client0-role1a-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '273'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:36 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/51087d42-6a13-46db-8eaa-5c65946cba54
-  response:
-    body:
-      string: '{"id":"51087d42-6a13-46db-8eaa-5c65946cba54","name":"ci0-client0-role1","description":"ci0-client0-role1-desc","composite":true,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","attributes":{"ci0-client0-role1-key0":["ci0-client0-role1-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '268'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/68ae87c4-e467-441b-82f5-6cff9dc478de
-  response:
-    body:
-      string: '{"id":"68ae87c4-e467-441b-82f5-6cff9dc478de","name":"ci0-client0-role0","description":"ci0-client0-role0-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","attributes":{"ci0-client0-role0-key0":["ci0-client0-role0-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '269'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/roles/ci0-client0-role1/composites
-  response:
-    body:
-      string: '[{"id":"91a1bfe5-f80d-44d8-9399-a62e89b1702b","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"f0470475-938b-4359-a575-2e9f68e255f3","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"},{"id":"66adc5f5-9cf8-454c-8907-9eb18594c923","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785"}]'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '570'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/scope-mappings/realm
-  response:
-    body:
-      string: '[{"id":"cfb27446-b485-4570-9bd9-28061f1bf526","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"49ae0b20-9085-43a2-b156-4948741a97c5","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '325'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/scope-mappings/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785
-  response:
-    body:
-      string: '[]'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '2'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785/scope-mappings/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e
-  response:
-    body:
-      string: '[{"id":"c98987f6-7e40-4c01-8d65-cbaefd433c28","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e"}]'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '202'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -658,8 +261,8 @@ interactions:
     uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients
   response:
     body:
-      string: '[{"id":"911d746e-55fb-4f4d-a006-1d1c8b4aaf6c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1b1c9d0e-f7f1-4f9b-8c37-c2a6b6f8d618","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"9c630e3d-0fbb-436b-b1b8-d9cd3b14d5c9","name":"audience
-        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"98b41d79-2ed0-42ec-8fe9-603d6cf0e551","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2ba411a3-ba1c-43ce-8f93-9842262004c4","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1e0807cf-7aa1-4ddf-8aa0-7d117d476785","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"c693d31d-c4ca-4fd7-9981-fa480905573f"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2d9e32dd-a26e-4baa-97ef-a36a3ebd13b6","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"ac88ad0e-e314-43fb-83e0-d676ba6d98cd","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"8a7ef691-a370-4a39-bd9d-cb016ebb79c4","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","profile","roles","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
+      string: '[{"id":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"7361940f-7d92-494a-8d76-532de091f940","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"69e7e632-f5dd-4ae0-bac5-b0e6e3cad929","name":"audience
+        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2da8e6c8-a57b-48b6-bd5e-db632529e920","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"92d68ae6-c1df-4f71-8e81-da09def6a279","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"81c9e6d8-0249-423d-bd43-6d61b0254eda","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"42702a64-a67e-46c9-ba0f-628cdef45045"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"5b05d663-6523-428a-8e2d-ecbb2c686182","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"d1091426-cb88-4bc3-9403-d919f2abd31d","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"6569f3a8-de45-42d5-9be7-e7c8fec20301","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"1a4270bf-7cfd-4327-a339-22e9f1baf205","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
     headers:
       Cache-Control:
       - no-cache
@@ -670,7 +273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -692,7 +295,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -700,21 +303,21 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e/roles
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/daab7ee6-94d8-43fa-ac30-da4935e1a420
   response:
     body:
-      string: '[{"id":"c98987f6-7e40-4c01-8d65-cbaefd433c28","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e"}]'
+      string: '{"id":"daab7ee6-94d8-43fa-ac30-da4935e1a420","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda","attributes":{"ci0-client0-role1a-key0":["ci0-client0-role1a-value0"]}}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
       Content-Length:
-      - '202'
+      - '273'
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -736,7 +339,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -744,10 +347,142 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/c98987f6-7e40-4c01-8d65-cbaefd433c28
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/0caa8580-16e9-4610-a7fc-47fc9f91c6cc
   response:
     body:
-      string: '{"id":"c98987f6-7e40-4c01-8d65-cbaefd433c28","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"1dcc0719-f6a0-487e-a54e-ae5e4271cc1e","attributes":{"ci0-client1-role0-key0":["ci0-client1-role0-value0"]}}'
+      string: '{"id":"0caa8580-16e9-4610-a7fc-47fc9f91c6cc","name":"ci0-client0-role1","description":"ci0-client0-role1-desc","composite":true,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda","attributes":{"ci0-client0-role1-key0":["ci0-client0-role1-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/0caa8580-16e9-4610-a7fc-47fc9f91c6cc/composites
+  response:
+    body:
+      string: '[{"id":"1e41e0e8-5882-4e81-aa69-1d516064ea86","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"daab7ee6-94d8-43fa-ac30-da4935e1a420","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"},{"id":"7e233ead-9628-4b26-9af3-26dddf42a673","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '570'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/7e233ead-9628-4b26-9af3-26dddf42a673
+  response:
+    body:
+      string: '{"id":"7e233ead-9628-4b26-9af3-26dddf42a673","name":"ci0-client0-role1b","description":"ci0-client0-role1b-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda","attributes":{"ci0-client0-role1b-key0":["ci0-client0-role1b-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '273'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/12a3d7f2-cb89-471d-9cb9-5c5497415fe6
+  response:
+    body:
+      string: '{"id":"12a3d7f2-cb89-471d-9cb9-5c5497415fe6","name":"ci0-client0-role0","description":"ci0-client0-role0-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda","attributes":{"ci0-client0-role0-key0":["ci0-client0-role0-value0"]}}'
     headers:
       Cache-Control:
       - no-cache
@@ -758,7 +493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -780,7 +515,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -788,21 +523,21 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e/scope-mappings/realm
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda/scope-mappings/realm
   response:
     body:
-      string: '[]'
+      string: '[{"id":"29e51e60-46f1-4fb1-81a4-9aecdc31c299","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"342935c1-40c4-4940-b6f8-efd28723df78","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
       Content-Length:
-      - '2'
+      - '325'
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -824,7 +559,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -832,7 +567,7 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e/scope-mappings/clients/1e0807cf-7aa1-4ddf-8aa0-7d117d476785
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda/scope-mappings/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda
   response:
     body:
       string: '[]'
@@ -846,7 +581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -868,7 +603,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJZdWFPa3NkT2FweWJWeHM4d21iNDNVWld6WmpQYkF0eEc5TXB6MEZ2M0lJIn0.eyJleHAiOjE2Njg0NjE1NTYsImlhdCI6MTY2ODQ2MTQ5NiwianRpIjoiNjNmYjRiNjEtOTZlYS00ZDZkLWExMGItMjQzZTk0YTcxMTUxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiNTlkYjI3ZjQtMDgyYS00YWE4LWEyOTEtZDZjNzgzYmJhZTA0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjA1YjdjMjdjLTkxMzctNDkxZS05YjIxLTdhMDcxOGE4YTcyZCIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIwNWI3YzI3Yy05MTM3LTQ5MWUtOWIyMS03YTA3MThhOGE3MmQiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.G77mQeCsxV5UKLlbofUI8bW7PwDPqB02VyngAOrcIJGPm_2b-ErXuFKcGJL6v803yc2I04ajxQrVJ9X22KfkXhDHDWxDid-EZw97KmnpG_NnIQelOdpoXyC8wGuv7B30mPW3A0eeoj7iVk5H4b4YfOb31j2xqfRBfexAD7WjB0yBgP8hIiHSJC_dRw-9qeDkS50Bx0kukylQUSfx9hCjB_KfAc1afW7laZYaXhlltdjwa5FnfIGRQjxGHjhc0SdYQaZKvKEsDTI_KwyzpQD2FICgpMFPzhJzHALnbsvs-eC2X4hnizHgE2swPMk9foBFVoVtlZJKNmnZ_DM-fn5AKQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
       Connection:
       - keep-alive
       Content-type:
@@ -876,7 +611,184 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e/scope-mappings/clients/1dcc0719-f6a0-487e-a54e-ae5e4271cc1e
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda/scope-mappings/clients/5b05d663-6523-428a-8e2d-ecbb2c686182
+  response:
+    body:
+      string: '[{"id":"2be4d184-6258-4b50-bc4d-1219db6452ea","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"5b05d663-6523-428a-8e2d-ecbb2c686182"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '202'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/5b05d663-6523-428a-8e2d-ecbb2c686182/roles
+  response:
+    body:
+      string: '[{"id":"2be4d184-6258-4b50-bc4d-1219db6452ea","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"5b05d663-6523-428a-8e2d-ecbb2c686182"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '202'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients
+  response:
+    body:
+      string: '[{"id":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"7361940f-7d92-494a-8d76-532de091f940","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"69e7e632-f5dd-4ae0-bac5-b0e6e3cad929","name":"audience
+        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2da8e6c8-a57b-48b6-bd5e-db632529e920","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"92d68ae6-c1df-4f71-8e81-da09def6a279","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"81c9e6d8-0249-423d-bd43-6d61b0254eda","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"42702a64-a67e-46c9-ba0f-628cdef45045"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"5b05d663-6523-428a-8e2d-ecbb2c686182","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"d1091426-cb88-4bc3-9403-d919f2abd31d","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"6569f3a8-de45-42d5-9be7-e7c8fec20301","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"1a4270bf-7cfd-4327-a339-22e9f1baf205","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '8644'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/2be4d184-6258-4b50-bc4d-1219db6452ea
+  response:
+    body:
+      string: '{"id":"2be4d184-6258-4b50-bc4d-1219db6452ea","name":"ci0-client1-role0","description":"ci0-client1-role0-desc","composite":false,"clientRole":true,"containerId":"5b05d663-6523-428a-8e2d-ecbb2c686182","attributes":{"ci0-client1-role0-key0":["ci0-client1-role0-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '269'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/5b05d663-6523-428a-8e2d-ecbb2c686182/scope-mappings/realm
   response:
     body:
       string: '[]'
@@ -890,7 +802,95 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 14 Nov 2022 21:31:37 GMT
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/5b05d663-6523-428a-8e2d-ecbb2c686182/scope-mappings/clients/81c9e6d8-0249-423d-bd43-6d61b0254eda
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MzA3NjgsImlhdCI6MTY2ODUzMDcwOCwianRpIjoiNWQ5MmYzMWUtY2RiOS00OTc5LWI4NmUtOWFhMGQxN2MxYmJkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjYyZTExZWJmLTlhYWQtNDhkOS1iZGFjLWFiYTE4ZmYzMzgxMyIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI2MmUxMWViZi05YWFkLTQ4ZDktYmRhYy1hYmExOGZmMzM4MTMiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.QEPoBubzwgv_9AcfHUgi2bM1dFyOj58B2HN-rA6xK_DwvgEFnn3P40Ho2Bqx3aPoHoViLkZ8KfozEEyT2qCq1g2W6NvyXSuJKjpMD4cHfOR5S6VjDZ2WDjxJAtPAijeijt_pzAsWH3pJ6J6O0-mnoeH4mLZZhxu5VwgTxF18_zb1wEZesHRq1boODHz4CrgxLz-Tn1G8rJuM47QKFCorRmFF3a9Cxb1gfhzvB7z3xoXAjaiXn3SHG4E5wlAW46QF-PdKK1lxXqgMk2KXB6pYFPHkize2odDdAVG5ONLZ-3VSbS4sqwZI5NBdid2QTJDISMZ3_VNw2yC1qn4vSGnI6A
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients/5b05d663-6523-428a-8e2d-ecbb2c686182/scope-mappings/clients/5b05d663-6523-428a-8e2d-ecbb2c686182
+  response:
+    body:
+      string: '[]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 16:45:08 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
+++ b/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
@@ -15,7 +15,7 @@ interactions:
   response:
     body:
       string: '{"issuer":"https://172.17.0.2:8443/auth/realms/master","authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth","token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","end_session_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/logout","jwks_uri":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/certs","check_session_iframe":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba"],"response_types_supported":["code","none","id_token","token","id_token
-        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","address","email","phone","roles","profile","web-origins","offline_access","microprofile-jwt"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
+        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","phone","profile","offline_access","microprofile-jwt","address","email","web-origins","roles"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
     headers:
       Cache-Control:
       - no-cache, must-revalidate, no-transform, no-store
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
+      - Tue, 15 Nov 2022 15:28:20 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -59,8 +59,8 @@ interactions:
     uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiY2Y4MmE3Ni1hZmE2LTQ2YzctYTc1Ny04YzFiN2M3MWNkNjcifQ.eyJleHAiOjE2Njg1MjQxODksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiNjgzNGQxYWItZTI5NS00MGI0LWJhOTctNGYzYmE4MjNhOWI1IiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIifQ.WFsIk57LSck2QFreVBqgrecw3EdimiJkDQeT0HD7OJg","token_type":"Bearer","not-before-policy":0,"session_state":"68a9ec07-a714-4de1-b9c8-f9903a9336d2","scope":"email
-        profile"}'
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzMjRiMjljYy0yYmQxLTRlMGItYmMwOC0yM2NhZmQzMzEyNzUifQ.eyJleHAiOjE2Njg1Mjc5MDAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiYmIzNWZjZWYtZjE0Yi00NzIzLWFlYWEtODAwOTliNWQzYzVlIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkifQ.vAC-sXr5YL4Bpx6D-E5KwvS74raYBbUOdoBxc3T_d9A","token_type":"Bearer","not-before-policy":0,"session_state":"5c7f8d67-707d-4685-aec1-50ced64db569","scope":"profile
+        email"}'
     headers:
       Cache-Control:
       - no-store
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
+      - Tue, 15 Nov 2022 15:28:20 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -100,7 +100,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
       Connection:
       - keep-alive
       Content-type:
@@ -111,18 +111,18 @@ interactions:
     uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles
   response:
     body:
-      string: '[{"id":"e695f124-d77c-41cb-8e1c-c3a2c135b10d","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"25fced3b-607a-4727-a09f-34b04272fe2c","name":"offline_access","description":"${role_offline-access}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"a17c147e-2e7d-4166-98e2-23ca511d9b38","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"2b164dd9-4194-4aaa-9354-2c2218a72593","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm"},{"id":"64e0212c-2032-4208-af5f-2523a47fd90b","name":"uma_authorization","description":"${role_uma_authorization}","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
+      string: '[{"id":"e85a3f07-3801-47a8-a49f-4acc21d0e457","name":"uma_authorization","description":"${role_uma_authorization}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"eea2be0b-4883-4000-9f23-fdac8cfb74a3","name":"offline_access","description":"${role_offline-access}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"b2ccf67f-eb23-4107-8b73-687980f33477","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm"},{"id":"1e41e0e8-5882-4e81-aa69-1d516064ea86","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"75fbdcc7-f88e-4ac4-891b-6d7f0722e8ad","name":"ci0-role-1","description":"ci0-role-1-desc","composite":true,"clientRole":false,"containerId":"ci0-realm"},{"id":"29e51e60-46f1-4fb1-81a4-9aecdc31c299","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"342935c1-40c4-4940-b6f8-efd28723df78","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
       Content-Length:
-      - '1017'
+      - '1177'
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
+      - Tue, 15 Nov 2022 15:28:20 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -144,7 +144,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
       Connection:
       - keep-alive
       Content-type:
@@ -152,142 +152,10 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/e695f124-d77c-41cb-8e1c-c3a2c135b10d
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/b2ccf67f-eb23-4107-8b73-687980f33477
   response:
     body:
-      string: '{"id":"e695f124-d77c-41cb-8e1c-c3a2c135b10d","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-0-key0":["ci0-role-0-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '215'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/a17c147e-2e7d-4166-98e2-23ca511d9b38
-  response:
-    body:
-      string: '{"id":"a17c147e-2e7d-4166-98e2-23ca511d9b38","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1a-key0":["ci0-role-1a-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '219'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/2b164dd9-4194-4aaa-9354-2c2218a72593
-  response:
-    body:
-      string: '{"id":"2b164dd9-4194-4aaa-9354-2c2218a72593","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1b-key0":["ci0-role-1b-value0"]}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '219'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
-      Referrer-Policy:
-      - no-referrer
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
-      Connection:
-      - keep-alive
-      Content-type:
-      - application/json
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7
-  response:
-    body:
-      string: '{"id":"f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm","attributes":{}}'
+      string: '{"id":"b2ccf67f-eb23-4107-8b73-687980f33477","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm","attributes":{}}'
     headers:
       Cache-Control:
       - no-cache
@@ -298,7 +166,183 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:26:29 GMT
+      - Tue, 15 Nov 2022 15:28:20 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/1e41e0e8-5882-4e81-aa69-1d516064ea86
+  response:
+    body:
+      string: '{"id":"1e41e0e8-5882-4e81-aa69-1d516064ea86","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1a-key0":["ci0-role-1a-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:28:20 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/75fbdcc7-f88e-4ac4-891b-6d7f0722e8ad
+  response:
+    body:
+      string: '{"id":"75fbdcc7-f88e-4ac4-891b-6d7f0722e8ad","name":"ci0-role-1","description":"ci0-role-1-desc","composite":true,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1-key0":["ci0-role-1-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '214'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:28:20 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/29e51e60-46f1-4fb1-81a4-9aecdc31c299
+  response:
+    body:
+      string: '{"id":"29e51e60-46f1-4fb1-81a4-9aecdc31c299","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-0-key0":["ci0-role-0-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '215'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:28:20 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/342935c1-40c4-4940-b6f8-efd28723df78
+  response:
+    body:
+      string: '{"id":"342935c1-40c4-4940-b6f8-efd28723df78","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1b-key0":["ci0-role-1b-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:28:20 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
+++ b/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
@@ -1,0 +1,139 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/realms/master/.well-known/openid-configuration
+  response:
+    body:
+      string: '{"issuer":"https://172.17.0.2:8443/auth/realms/master","authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth","token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","end_session_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/logout","jwks_uri":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/certs","check_session_iframe":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/login-status-iframe.html","grant_types_supported":["authorization_code","implicit","refresh_token","password","client_credentials","urn:ietf:params:oauth:grant-type:device_code","urn:openid:params:grant-type:ciba"],"response_types_supported":["code","none","id_token","token","id_token
+        token","code id_token","code token","code id_token token"],"subject_types_supported":["public","pairwise"],"id_token_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"id_token_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"id_token_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"userinfo_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512","none"],"request_object_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"request_object_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"response_modes_supported":["query","fragment","form_post","query.jwt","fragment.jwt","form_post.jwt","jwt"],"registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","token_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"token_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"introspection_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"introspection_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"authorization_encryption_alg_values_supported":["RSA-OAEP","RSA-OAEP-256","RSA1_5"],"authorization_encryption_enc_values_supported":["A256GCM","A192GCM","A128GCM","A128CBC-HS256","A192CBC-HS384","A256CBC-HS512"],"claims_supported":["aud","sub","iss","auth_time","name","given_name","family_name","preferred_username","email","acr"],"claim_types_supported":["normal"],"claims_parameter_supported":true,"scopes_supported":["openid","address","email","phone","roles","profile","web-origins","offline_access","microprofile-jwt"],"request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"code_challenge_methods_supported":["plain","S256"],"tls_client_certificate_bound_access_tokens":true,"revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","revocation_endpoint_auth_methods_supported":["private_key_jwt","client_secret_basic","client_secret_post","tls_client_auth","client_secret_jwt"],"revocation_endpoint_auth_signing_alg_values_supported":["PS384","ES384","RS384","HS256","HS512","ES256","RS256","HS384","ES512","PS256","PS512","RS512"],"backchannel_logout_supported":true,"backchannel_logout_session_supported":true,"device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","backchannel_token_delivery_modes_supported":["poll","ping"],"backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth","backchannel_authentication_request_signing_alg_values_supported":["PS384","ES384","RS384","ES256","RS256","ES512","PS256","PS512","RS512"],"require_pushed_authorization_requests":false,"pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","mtls_endpoint_aliases":{"token_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token","revocation_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/revoke","introspection_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token/introspect","device_authorization_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/auth/device","registration_endpoint":"https://172.17.0.2:8443/auth/realms/master/clients-registrations/openid-connect","userinfo_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/userinfo","pushed_authorization_request_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/par/request","backchannel_authentication_endpoint":"https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/ext/ciba/auth"}}'
+    headers:
+      Cache-Control:
+      - no-cache, must-revalidate, no-transform, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '5646'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:18:49 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: client_id=admin-cli&grant_type=password&realm=master&username=admin&password=admin
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '82'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.28.1
+    method: POST
+    uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
+  response:
+    body:
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjE5ODksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiOWZiYzg4ZGUtMjE1MC00ZjBkLWI0YzktYTlhMDU1MjA4NGNkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjI5Nzg5ZmI0LWZjYzYtNDM4My05YmMyLTI0OTc0ODg3NjNmMSIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.R5Z05h4ngDvuFivQB0adVUx2I3z277DAmDMEB0Kb4xn3bZHzrCRtetB9Z8vbyb6O1JjZDjsE-9OvEXbw7zjzbcLrD7fWj9UDUqa_Q5DFItGep8jZ93tcQB3yO-4GFG-wxdHbCOIDXN9eeNhakcXRORITxWpc2_6FWsGpufX-aFpej_EfW2vBfpfpHnJVmrAMu7ZZnd950_kx-JZ80KckmbWsE3Ex_8BUwt8VpwGIo_93gckkUNT1Spe6qPNMZ9aaJFWGZT5jvsZYJF-9RT3fvdL3yyRQ4vIznrS5JrvY_CjiuMHL1ea-XjLcWpAX6zvz0u_7mShORBSQNi5tE2CJ8g","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiY2Y4MmE3Ni1hZmE2LTQ2YzctYTc1Ny04YzFiN2M3MWNkNjcifQ.eyJleHAiOjE2Njg1MjM3MjksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiZjI0OTVhOTEtY2M0MC00ZDUyLTg1ZDQtZjQyYTA5ZWY5YzYxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEifQ.nKpfQWqzQkLg-uYE2f13saiKecNkm_oZWYsGbA75-4M","token_type":"Bearer","not-before-policy":0,"session_state":"29789fb4-fcc6-4383-9bc2-2497488763f1","scope":"email
+        profile"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1846'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:18:49 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - no-referrer
+      Set-Cookie:
+      - KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970
+        00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
+      - KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0;
+        Path=/auth/realms/master/; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjE5ODksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiOWZiYzg4ZGUtMjE1MC00ZjBkLWI0YzktYTlhMDU1MjA4NGNkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjI5Nzg5ZmI0LWZjYzYtNDM4My05YmMyLTI0OTc0ODg3NjNmMSIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.R5Z05h4ngDvuFivQB0adVUx2I3z277DAmDMEB0Kb4xn3bZHzrCRtetB9Z8vbyb6O1JjZDjsE-9OvEXbw7zjzbcLrD7fWj9UDUqa_Q5DFItGep8jZ93tcQB3yO-4GFG-wxdHbCOIDXN9eeNhakcXRORITxWpc2_6FWsGpufX-aFpej_EfW2vBfpfpHnJVmrAMu7ZZnd950_kx-JZ80KckmbWsE3Ex_8BUwt8VpwGIo_93gckkUNT1Spe6qPNMZ9aaJFWGZT5jvsZYJF-9RT3fvdL3yyRQ4vIznrS5JrvY_CjiuMHL1ea-XjLcWpAX6zvz0u_7mShORBSQNi5tE2CJ8g
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles
+  response:
+    body:
+      string: '[{"id":"e695f124-d77c-41cb-8e1c-c3a2c135b10d","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"25fced3b-607a-4727-a09f-34b04272fe2c","name":"offline_access","description":"${role_offline-access}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"a17c147e-2e7d-4166-98e2-23ca511d9b38","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"2b164dd9-4194-4aaa-9354-2c2218a72593","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm"},{"id":"64e0212c-2032-4208-af5f-2523a47fd90b","name":"uma_authorization","description":"${role_uma_authorization}","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1017'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:18:49 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
+++ b/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -59,7 +59,7 @@ interactions:
     uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzMjRiMjljYy0yYmQxLTRlMGItYmMwOC0yM2NhZmQzMzEyNzUifQ.eyJleHAiOjE2Njg1Mjc5MDAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiYmIzNWZjZWYtZjE0Yi00NzIzLWFlYWEtODAwOTliNWQzYzVlIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkifQ.vAC-sXr5YL4Bpx6D-E5KwvS74raYBbUOdoBxc3T_d9A","token_type":"Bearer","not-before-policy":0,"session_state":"5c7f8d67-707d-4685-aec1-50ced64db569","scope":"profile
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzMjRiMjljYy0yYmQxLTRlMGItYmMwOC0yM2NhZmQzMzEyNzUifQ.eyJleHAiOjE2Njg1Mjk2NDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiZjFmMDMwNjAtYjkwZC00MjE2LWEyZTQtNjNiMjNiMGI2ZDZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIifQ.MnJCqXnW2_WBFZ6GXltNq4ZYAlLSqJg1BmnIfS5SGO4","token_type":"Bearer","not-before-policy":0,"session_state":"70d17b54-45f1-4efe-8c6b-3ffa2cdde1eb","scope":"profile
         email"}'
     headers:
       Cache-Control:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -100,7 +100,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -122,7 +122,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -144,7 +144,52 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/clients
+  response:
+    body:
+      string: '[{"id":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c","clientId":"account","name":"${client_account}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"7361940f-7d92-494a-8d76-532de091f940","clientId":"account-console","name":"${client_account-console}","rootUrl":"${authBaseUrl}","baseUrl":"/realms/ci0-realm/account/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/realms/ci0-realm/account/*"],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"69e7e632-f5dd-4ae0-bac5-b0e6e3cad929","name":"audience
+        resolve","protocol":"openid-connect","protocolMapper":"oidc-audience-resolve-mapper","consentRequired":false,"config":{}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"2da8e6c8-a57b-48b6-bd5e-db632529e920","clientId":"admin-cli","name":"${client_admin-cli}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":false,"implicitFlowEnabled":false,"directAccessGrantsEnabled":true,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"92d68ae6-c1df-4f71-8e81-da09def6a279","clientId":"broker","name":"${client_broker}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"81c9e6d8-0249-423d-bd43-6d61b0254eda","clientId":"ci0-client-0","name":"ci0-client-0-name","description":"ci0-client-0-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-0.example.com/redirect-url"],"webOrigins":["https://ci0-client-0.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"access.token.lifespan":"600","saml.force.post.binding":"false","saml.multivalued.roles":"false","oauth2.device.authorization.grant.enabled":"false","backchannel.logout.revoke.offline.tokens":"false","saml.server.signature.keyinfo.ext":"false","use.refresh.tokens":"true","oidc.ciba.grant.enabled":"false","backchannel.logout.session.required":"false","client_credentials.use_refresh_token":"false","require.pushed.authorization.requests":"false","saml.client.signature":"false","id.token.as.detached.signature":"false","saml.assertion.signature":"false","saml.encrypt":"false","access.token.signed.response.alg":"ES256","saml.server.signature":"false","exclude.session.state.from.auth.response":"true","saml.artifact.binding":"false","saml_force_name_id_format":"false","tls.client.certificate.bound.access.tokens":"false","saml.authnstatement":"false","display.on.consent.screen":"false","saml.onetimeuse.condition":"false"},"authenticationFlowBindingOverrides":{"browser":"42702a64-a67e-46c9-ba0f-628cdef45045"},"fullScopeAllowed":false,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"5b05d663-6523-428a-8e2d-ecbb2c686182","clientId":"ci0-client-1","name":"ci0-client-1-name","description":"ci0-client-1-desc","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["https://ci0-client-1.example.com/redirect-url"],"webOrigins":["https://ci0-client-1.example.com"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":true,"nodeReRegistrationTimeout":-1,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"d1091426-cb88-4bc3-9403-d919f2abd31d","clientId":"realm-management","name":"${client_realm-management}","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":[],"webOrigins":[],"notBefore":0,"bearerOnly":true,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":false,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}},{"id":"6569f3a8-de45-42d5-9be7-e7c8fec20301","clientId":"security-admin-console","name":"${client_security-admin-console}","rootUrl":"${authAdminUrl}","baseUrl":"/admin/ci0-realm/console/","surrogateAuthRequired":false,"enabled":true,"alwaysDisplayInConsole":false,"clientAuthenticatorType":"client-secret","redirectUris":["/admin/ci0-realm/console/*"],"webOrigins":["+"],"notBefore":0,"bearerOnly":false,"consentRequired":false,"standardFlowEnabled":true,"implicitFlowEnabled":false,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"publicClient":true,"frontchannelLogout":false,"protocol":"openid-connect","attributes":{"pkce.code.challenge.method":"S256"},"authenticationFlowBindingOverrides":{},"fullScopeAllowed":false,"nodeReRegistrationTimeout":0,"protocolMappers":[{"id":"1a4270bf-7cfd-4327-a339-22e9f1baf205","name":"locale","protocol":"openid-connect","protocolMapper":"oidc-usermodel-attribute-mapper","consentRequired":false,"config":{"userinfo.token.claim":"true","user.attribute":"locale","id.token.claim":"true","access.token.claim":"true","claim.name":"locale","jsonType.label":"String"}}],"defaultClientScopes":["web-origins","roles","profile","email"],"optionalClientScopes":["address","phone","offline_access","microprofile-jwt"],"access":{"view":true,"configure":true,"manage":true}}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '8644'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:57:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -166,7 +211,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -188,7 +233,51 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/b2ccf67f-eb23-4107-8b73-687980f33477/composites
+  response:
+    body:
+      string: '[{"id":"e85a3f07-3801-47a8-a49f-4acc21d0e457","name":"uma_authorization","description":"${role_uma_authorization}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"b609694f-0237-4c99-ad6f-88bde295c23c","name":"manage-account","description":"${role_manage-account}","composite":true,"clientRole":true,"containerId":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c"},{"id":"eea2be0b-4883-4000-9f23-fdac8cfb74a3","name":"offline_access","description":"${role_offline-access}","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"d6685b3d-b34f-4fd1-a5b2-cfbabab1cecc","name":"view-profile","description":"${role_view-profile}","composite":false,"clientRole":true,"containerId":"7b4f0bf2-5f96-4f8f-b390-2270d41b0d1c"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:57:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -210,7 +299,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -232,7 +321,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -254,7 +343,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -276,7 +365,51 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/75fbdcc7-f88e-4ac4-891b-6d7f0722e8ad/composites
+  response:
+    body:
+      string: '[{"id":"1e41e0e8-5882-4e81-aa69-1d516064ea86","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"},{"id":"daab7ee6-94d8-43fa-ac30-da4935e1a420","name":"ci0-client0-role1a","description":"ci0-client0-role1a-desc","composite":false,"clientRole":true,"containerId":"81c9e6d8-0249-423d-bd43-6d61b0254eda"},{"id":"342935c1-40c4-4940-b6f8-efd28723df78","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm"}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '530'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 15:57:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -298,7 +431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -320,7 +453,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1MjYxNjAsImlhdCI6MTY2ODUyNjEwMCwianRpIjoiY2JmMjZlZTMtNWRiNS00NGE3LWI4NTItZTBhOTQxMTE4ZDQwIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjVjN2Y4ZDY3LTcwN2QtNDY4NS1hZWMxLTUwY2VkNjRkYjU2OSIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI1YzdmOGQ2Ny03MDdkLTQ2ODUtYWVjMS01MGNlZDY0ZGI1NjkiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.gJCSedAve_5CMaCCXs-tqxMl7xWL34urn3OmQ930pufXHOk65Xa6dqZpfnZCPhcyzk3t2Wn2ble3_w1I3QfHQEDpWNToCdfYczDPVF4uDQZBspBu_2fuEIE8Vxr0B6b29N-WlI3VJxvt6iUZ7L42cdHyaxujlVYtdRvq2vfHXzCVDlob5eHQB4txrN4_oc_GoEMcjIAr962fMIWFsywjpIbbGMFtMTwBlSnd-5g0USYqmUJDDZ1NJ3ECu6n3t2yQi5we8TyvYHJOTt2r0MZWje8Wwyf7-cp2GGtdNJB28YCwVcuTJ-7RB5raHbCf3WPdPt2MdjKZQuJTYnOhVHdinQ
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJxQnpvVVZZM1I2VWVSOTFFUjV5MGpPdzhXSFc2WXBTWDIxY0JVb1M5UkVFIn0.eyJleHAiOjE2Njg1Mjc5MDksImlhdCI6MTY2ODUyNzg0OSwianRpIjoiMTk0NWEwNTYtYzVhMy00OGJmLThjNzYtZmY0OWVkZmM2NGZjIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDFiMDE0ZWMtMDY3NS00MTZkLTgwZmEtMmNhNzY0Zjc3NmI1IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjcwZDE3YjU0LTQ1ZjEtNGVmZS04YzZiLTNmZmEyY2RkZTFlYiIsImFjciI6IjEiLCJzY29wZSI6InByb2ZpbGUgZW1haWwiLCJzaWQiOiI3MGQxN2I1NC00NWYxLTRlZmUtOGM2Yi0zZmZhMmNkZGUxZWIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.fbx27lNWgnuduaxpbKE-zsXxaVd-kXZmylv4ER3TkFJQP6ufZhfJMOz2s6_LTMLXrkoN6YVW1HQ_qAX8dFAzCUBd5TFEi1Mmv1kMY4nEjb-p2H9M2iTcRETzEbpptIPs_S-WKmE-BlcmU48unL4-4m0NOkrMhrrRWW_dhpX22-rchVXzd4_mFE1hlxDx8NKrV6TcWHIYfKGvxxgxNlkiChV8H_WQixmxeHlsyCmctwVWwKY88Ftz4B1-cA0SvsawM7vc9glv9d95Ju4gsXgMmjG7-sGKSyjekzhnqChx9_Xz49XyNlpsL0_1zY0rY08VPrbxTKE7R0quajqC4kix8w
       Connection:
       - keep-alive
       Content-type:
@@ -342,7 +475,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 15:28:20 GMT
+      - Tue, 15 Nov 2022 15:57:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
+++ b/tests/unit/fetch/cassettes/TestRoleFetch_vcr.test__get_data.yaml
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:18:49 GMT
+      - Tue, 15 Nov 2022 14:26:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:
@@ -59,7 +59,7 @@ interactions:
     uri: https://172.17.0.2:8443/auth/realms/master/protocol/openid-connect/token
   response:
     body:
-      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjE5ODksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiOWZiYzg4ZGUtMjE1MC00ZjBkLWI0YzktYTlhMDU1MjA4NGNkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjI5Nzg5ZmI0LWZjYzYtNDM4My05YmMyLTI0OTc0ODg3NjNmMSIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.R5Z05h4ngDvuFivQB0adVUx2I3z277DAmDMEB0Kb4xn3bZHzrCRtetB9Z8vbyb6O1JjZDjsE-9OvEXbw7zjzbcLrD7fWj9UDUqa_Q5DFItGep8jZ93tcQB3yO-4GFG-wxdHbCOIDXN9eeNhakcXRORITxWpc2_6FWsGpufX-aFpej_EfW2vBfpfpHnJVmrAMu7ZZnd950_kx-JZ80KckmbWsE3Ex_8BUwt8VpwGIo_93gckkUNT1Spe6qPNMZ9aaJFWGZT5jvsZYJF-9RT3fvdL3yyRQ4vIznrS5JrvY_CjiuMHL1ea-XjLcWpAX6zvz0u_7mShORBSQNi5tE2CJ8g","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiY2Y4MmE3Ni1hZmE2LTQ2YzctYTc1Ny04YzFiN2M3MWNkNjcifQ.eyJleHAiOjE2Njg1MjM3MjksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiZjI0OTVhOTEtY2M0MC00ZDUyLTg1ZDQtZjQyYTA5ZWY5YzYxIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEifQ.nKpfQWqzQkLg-uYE2f13saiKecNkm_oZWYsGbA75-4M","token_type":"Bearer","not-before-policy":0,"session_state":"29789fb4-fcc6-4383-9bc2-2497488763f1","scope":"email
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw","expires_in":60,"refresh_expires_in":1800,"refresh_token":"eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJiY2Y4MmE3Ni1hZmE2LTQ2YzctYTc1Ny04YzFiN2M3MWNkNjcifQ.eyJleHAiOjE2Njg1MjQxODksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiNjgzNGQxYWItZTI5NS00MGI0LWJhOTctNGYzYmE4MjNhOWI1IiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIifQ.WFsIk57LSck2QFreVBqgrecw3EdimiJkDQeT0HD7OJg","token_type":"Bearer","not-before-policy":0,"session_state":"68a9ec07-a714-4de1-b9c8-f9903a9336d2","scope":"email
         profile"}'
     headers:
       Cache-Control:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:18:49 GMT
+      - Tue, 15 Nov 2022 14:26:29 GMT
       Pragma:
       - no-cache
       Referrer-Policy:
@@ -100,7 +100,7 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjE5ODksImlhdCI6MTY2ODUyMTkyOSwianRpIjoiOWZiYzg4ZGUtMjE1MC00ZjBkLWI0YzktYTlhMDU1MjA4NGNkIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjI5Nzg5ZmI0LWZjYzYtNDM4My05YmMyLTI0OTc0ODg3NjNmMSIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiIyOTc4OWZiNC1mY2M2LTQzODMtOWJjMi0yNDk3NDg4NzYzZjEiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.R5Z05h4ngDvuFivQB0adVUx2I3z277DAmDMEB0Kb4xn3bZHzrCRtetB9Z8vbyb6O1JjZDjsE-9OvEXbw7zjzbcLrD7fWj9UDUqa_Q5DFItGep8jZ93tcQB3yO-4GFG-wxdHbCOIDXN9eeNhakcXRORITxWpc2_6FWsGpufX-aFpej_EfW2vBfpfpHnJVmrAMu7ZZnd950_kx-JZ80KckmbWsE3Ex_8BUwt8VpwGIo_93gckkUNT1Spe6qPNMZ9aaJFWGZT5jvsZYJF-9RT3fvdL3yyRQ4vIznrS5JrvY_CjiuMHL1ea-XjLcWpAX6zvz0u_7mShORBSQNi5tE2CJ8g
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
       Connection:
       - keep-alive
       Content-type:
@@ -122,7 +122,183 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 15 Nov 2022 14:18:49 GMT
+      - Tue, 15 Nov 2022 14:26:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/e695f124-d77c-41cb-8e1c-c3a2c135b10d
+  response:
+    body:
+      string: '{"id":"e695f124-d77c-41cb-8e1c-c3a2c135b10d","name":"ci0-role-0","description":"ci0-role-0-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-0-key0":["ci0-role-0-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '215'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:26:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/a17c147e-2e7d-4166-98e2-23ca511d9b38
+  response:
+    body:
+      string: '{"id":"a17c147e-2e7d-4166-98e2-23ca511d9b38","name":"ci0-role-1a","description":"ci0-role-1a-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1a-key0":["ci0-role-1a-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:26:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/2b164dd9-4194-4aaa-9354-2c2218a72593
+  response:
+    body:
+      string: '{"id":"2b164dd9-4194-4aaa-9354-2c2218a72593","name":"ci0-role-1b","description":"ci0-role-1b-desc","composite":false,"clientRole":false,"containerId":"ci0-realm","attributes":{"ci0-role-1b-key0":["ci0-role-1b-value0"]}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '219'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:26:29 GMT
+      Referrer-Policy:
+      - no-referrer
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIxN05PTmJBWjctRjZMYkZibS1saXVLbjVQdE96MDVQTEVnT3ZPcWV5SVBnIn0.eyJleHAiOjE2Njg1MjI0NDksImlhdCI6MTY2ODUyMjM4OSwianRpIjoiN2FlNWIyNTgtNWI1OS00NjkwLWI4YjQtOGY4YjU4MDliNTFiIiwiaXNzIjoiaHR0cHM6Ly8xNzIuMTcuMC4yOjg0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiYmNjNmRlODYtM2M5ZS00N2U3LWJlODQtNDE0YTIyMzcxYjAwIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjY4YTllYzA3LWE3MTQtNGRlMS1iOWM4LWY5OTAzYTkzMzZkMiIsImFjciI6IjEiLCJzY29wZSI6ImVtYWlsIHByb2ZpbGUiLCJzaWQiOiI2OGE5ZWMwNy1hNzE0LTRkZTEtYjljOC1mOTkwM2E5MzM2ZDIiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsInByZWZlcnJlZF91c2VybmFtZSI6ImFkbWluIn0.lspfh7tKgp-BBwkhN6ofddZjmRkz_4psoeyziDPuXpTOCORBBkjVO7XbV76t9VroXRTtu4z6mRH472tO--ViIZTA-bv1Lu1stV0io1tpnOUCyxW2LFshc-otOByj5DfEQsALUAkJPWieQ4nO2X2LBK3BCUAQQQfxVEAK-vOxevg8mdjH5lj7k2ttKknCobOaCneVLM69ng9RIae505y_LBCWyTHjBc0RHY0hVgMOBELZSYVo_UouByn4bPIy3LKhVxCA1YfOicE9zQ09TZOsg1QsUpilSXVzS-93Egk-8JgNzBBgdfzHDCMMLefBDQcIrWhUTidH8Wso3lI-mq5jSw
+      Connection:
+      - keep-alive
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: https://172.17.0.2:8443/auth/admin/realms/ci0-realm/roles-by-id/f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7
+  response:
+    body:
+      string: '{"id":"f7aec3e1-c1c4-40f8-9481-38a73fb8f4c7","name":"default-roles-ci0-realm","description":"${role_default-roles}","composite":true,"clientRole":false,"containerId":"ci0-realm","attributes":{}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 15 Nov 2022 14:26:29 GMT
       Referrer-Policy:
       - no-referrer
       Strict-Transport-Security:

--- a/tests/unit/fetch/test_client.py
+++ b/tests/unit/fetch/test_client.py
@@ -29,10 +29,17 @@ class TestClientFetch_vcr:
         # check generated content
         assert os.listdir(datadir) == unordered(["client-0", "client-1"])
         assert os.listdir(os.path.join(datadir, "client-0")) == unordered(['ci0-client-0.json', 'scope-mappings.json', 'roles'])
-        assert os.listdir(os.path.join(datadir, "client-0/roles")) == ['roles.json']
+        assert os.listdir(os.path.join(datadir, "client-0/roles")) == unordered([
+            'ci0-client0-role0.json',
+            'ci0-client0-role1.json',
+            'ci0-client0-role1b.json',
+            'ci0-client0-role1a.json',
+        ])
         assert os.listdir(os.path.join(datadir, "client-1")) == unordered(['ci0-client-1.json', 'scope-mappings.json', 'roles'])
-        assert os.listdir(os.path.join(datadir, "client-1/roles")) == ['roles.json']
-        #
+        assert os.listdir(os.path.join(datadir, "client-1/roles")) == unordered([
+            'ci0-client1-role0.json',
+        ])
+
         data = json.load(open(os.path.join(datadir, "client-0/ci0-client-0.json")))
         assert list(data.keys()) == [
             'access',
@@ -64,7 +71,6 @@ class TestClientFetch_vcr:
         ]
         assert data["clientId"] == "ci0-client-0"
         assert data["name"] == "ci0-client-0-name"
-        assert os.listdir(os.path.join(datadir, "client-0/roles")) == ['roles.json']
 
         # authenticationFlowBindingOverrides must contain names, not UUIDs
         assert isinstance(data["authenticationFlowBindingOverrides"], dict)
@@ -98,11 +104,7 @@ class TestClientFetch_vcr:
 
         # =======================================================================================
         # Check client role
-        data = json.load(open(os.path.join(datadir, "client-0/roles/roles.json")))
-        assert isinstance(data, list)
-        assert len(data) == 4
-
-        role = find_in_list(data, name="ci0-client0-role0")
+        role = json.load(open(os.path.join(datadir, "client-0/roles/ci0-client0-role0.json")))
         assert list(role.keys()) == [
             'attributes',
             'clientRole',
@@ -119,7 +121,7 @@ class TestClientFetch_vcr:
         assert role["composite"] is False
         assert role["attributes"] == {"ci0-client0-role0-key0": ["ci0-client0-role0-value0"]}
 
-        role = find_in_list(data, name="ci0-client0-role1")
+        role = json.load(open(os.path.join(datadir, "client-0/roles/ci0-client0-role1.json")))
         assert list(role.keys()) == [
             'attributes',
             'clientRole',

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -47,15 +47,40 @@ class TestRoleFetch_vcr:
         assert data["name"] == "ci0-role-0"
         assert data["clientRole"] is False
         assert data["composite"] is False
+        assert data["attributes"] == {"ci0-role-0-key0": ["ci0-role-0-value0"]}
 
         data = json.load(open(os.path.join(datadir, "ci0-role-1.json")))
         assert list(data.keys()) == [
             'attributes',
             'clientRole',
             'composite',
+            'composites',
             'description',
             'name',
         ]
         assert data["name"] == "ci0-role-1"
         assert data["clientRole"] is False
         assert data["composite"] is True
+        assert data["attributes"] == {"ci0-role-1-key0": ["ci0-role-1-value0"]}
+        assert len(data["composites"]) == 3
+        #
+        composites_sorted = sorted(data["composites"], key=lambda obj: obj["name"])
+        assert list(composites_sorted[0].keys()) == [
+            'clientRole',
+            # 'composite',
+            'containerName',
+            # 'description',
+            'name',
+        ]
+        # check only important attributes.
+        assert composites_sorted[0]["clientRole"] is True
+        assert composites_sorted[0]["containerName"] == "ci0-client-0"
+        assert composites_sorted[0]["name"] == "ci0-client0-role1a"
+        #
+        assert composites_sorted[1]["clientRole"] is False
+        assert composites_sorted[1]["containerName"] == "ci0-realm"
+        assert composites_sorted[1]["name"] == "ci0-role-1a"
+        #
+        assert composites_sorted[2]["clientRole"] is False
+        assert composites_sorted[2]["containerName"] == "ci0-realm"
+        assert composites_sorted[2]["name"] == "ci0-role-1b"

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -3,7 +3,7 @@ from pytest_unordered import unordered
 import json
 import os
 import shutil
-from kcfetcher.fetch import GenericFetch
+from kcfetcher.fetch import RoleFetch
 from kcfetcher.store import Store
 from kcfetcher.utils import remove_folder, make_folder, login
 
@@ -23,7 +23,7 @@ class TestRoleFetch_vcr:
         resource_name = "roles"
         resource_identifier = "name"
 
-        obj = GenericFetch(kc, resource_name, resource_identifier, realm_name)
+        obj = RoleFetch(kc, resource_name, resource_identifier, realm_name)
 
         obj.fetch(store_api)
 
@@ -37,6 +37,7 @@ class TestRoleFetch_vcr:
         #
         data = json.load(open(os.path.join(datadir, "ci0-role-0.json")))
         assert list(data.keys()) == [
+            'attributes',
             'clientRole',
             'composite',
             'containerId', # TODO remove

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -30,11 +30,12 @@ class TestRoleFetch_vcr:
         # check generated content
         assert unordered(os.listdir(datadir)) == [
             'ci0-role-0.json',
+            'ci0-role-1.json',
             'ci0-role-1a.json',
             'ci0-role-1b.json',
             'default-roles-ci0-realm.json',
         ]
-        #
+
         data = json.load(open(os.path.join(datadir, "ci0-role-0.json")))
         assert list(data.keys()) == [
             'attributes',
@@ -47,3 +48,14 @@ class TestRoleFetch_vcr:
         assert data["clientRole"] is False
         assert data["composite"] is False
 
+        data = json.load(open(os.path.join(datadir, "ci0-role-1.json")))
+        assert list(data.keys()) == [
+            'attributes',
+            'clientRole',
+            'composite',
+            'description',
+            'name',
+        ]
+        assert data["name"] == "ci0-role-1"
+        assert data["clientRole"] is False
+        assert data["composite"] is True

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -40,7 +40,6 @@ class TestRoleFetch_vcr:
             'attributes',
             'clientRole',
             'composite',
-            'containerId', # TODO remove
             'description',
             'name',
         ]

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -1,0 +1,49 @@
+from pytest import mark
+from pytest_unordered import unordered
+import json
+import os
+import shutil
+from kcfetcher.fetch import GenericFetch
+from kcfetcher.store import Store
+from kcfetcher.utils import remove_folder, make_folder, login
+
+
+@mark.vcr()
+class TestRoleFetch_vcr:
+    def test__get_data(self):
+        datadir = "output/ci/outd"
+        remove_folder(datadir)
+        make_folder(datadir)
+        store_api = Store(datadir)
+        server = os.environ["SSO_API_URL"]
+        user = os.environ["SSO_API_USERNAME"]
+        password = os.environ["SSO_API_PASSWORD"]
+        kc = login(server, user, password)
+        realm_name = "ci0-realm"
+        resource_name = "roles"
+        resource_identifier = "name"
+
+        obj = GenericFetch(kc, resource_name, resource_identifier, realm_name)
+
+        obj.fetch(store_api)
+
+        # check generated content
+        assert unordered(os.listdir(datadir)) == [
+            'ci0-role-0.json',
+            'ci0-role-1a.json',
+            'ci0-role-1b.json',
+            'default-roles-ci0-realm.json',
+        ]
+        #
+        data = json.load(open(os.path.join(datadir, "ci0-role-0.json")))
+        assert list(data.keys()) == [
+            'clientRole',
+            'composite',
+            'containerId', # TODO remove
+            'description',
+            'name',
+        ]
+        assert data["name"] == "ci0-role-0"
+        assert data["clientRole"] is False
+        assert data["composite"] is False
+


### PR DESCRIPTION
CI data is extended to include a composite realm role. It contains both realm roles and client roles.

Code is fixed to export both composite role - the `RoleFetch` class. Also all (realm) role attributes are exported.

Client role export code is modified to reuse `RoleFetch` class.  