### PR TITLE
Sort output

### DIFF
--- a/kcfetcher/store/store.py
+++ b/kcfetcher/store/store.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from kcfetcher.utils import make_folder, remove_ids, normalize
+from kcfetcher.utils import make_folder, remove_ids, normalize, sort_json
+
 
 class Store:
     def __init__(self, path=''):
@@ -23,6 +24,7 @@ class Store:
 
         file = open(path + '/' + normalize(alias) + '.json', 'w')
         data = remove_ids(data)
+        data = sort_json(data)
         json.dump(data, file, indent=4, sort_keys=True)
         file.close()
 

--- a/kcfetcher/utils/__init__.py
+++ b/kcfetcher/utils/__init__.py
@@ -1,5 +1,5 @@
 from .helper import remove_folder, make_folder, remove_ids, normalize, login, find_in_list, minimize_role_representation
-from .helper import RH_SSO_VERSIONS_7_4, RH_SSO_VERSIONS_7_5
+from .helper import RH_SSO_VERSIONS_7_4, RH_SSO_VERSIONS_7_5, sort_json
 
 __all__ = [
     remove_folder,
@@ -9,6 +9,7 @@ __all__ = [
     login,
     find_in_list,
     minimize_role_representation,
+    sort_json,
     RH_SSO_VERSIONS_7_4,
     RH_SSO_VERSIONS_7_5,
 ]

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from copy import copy
 
 from kcapi import OpenID, Keycloak
 
@@ -56,6 +57,11 @@ def remove_ids(kc_object={}):
     # each dict element needs to be cleaned recursively
     assert isinstance(kc_object, dict)
     return {key: remove_ids(kc_object[key]) for key in kc_object if key not in ['id', 'flowId']}
+
+
+def sort_json(data):
+    dd = copy(data)
+    return dd
 
 
 def login(endpoint, user, password, read_token_from_file=False):

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -60,7 +60,47 @@ def remove_ids(kc_object={}):
 
 
 def sort_json(data):
+    # We want to sort:
+    # - list of dict, sort by "name" attribute
+    # - dict of dict, sort by "name" attribute
+    # We sort by name, clientId, maybe more.
+
     dd = copy(data)
+
+    # simple scalar values are safe to return
+    if isinstance(dd, (str, bool, int, float)):
+        return dd
+
+    if isinstance(dd, list):
+        if not dd:
+            return dd
+        if not isinstance(dd[0], dict):
+            return dd
+        # we have list of dict
+        key = "name"
+        if key not in dd[0]:
+            return dd
+        # composites_sorted = sorted(data["composites"], key=lambda obj: obj["name"])
+        dd_sorted = sorted(dd, key=lambda obj: obj[key])
+        return dd_sorted
+
+    # sort allowed-protocol-mapper-types
+    assert isinstance(dd, dict)
+    if "config" in dd and \
+            isinstance(dd["config"], dict) and \
+            "allowed-protocol-mapper-types" in dd["config"] and \
+            isinstance(dd["config"]["allowed-protocol-mapper-types"], list):
+        dd["config"]["allowed-protocol-mapper-types"] = sorted(dd["config"]["allowed-protocol-mapper-types"])
+
+    # sort client.json - defaultClientScopes
+    if "defaultClientScopes" in dd and \
+            isinstance(dd["defaultClientScopes"], list):
+        dd["defaultClientScopes"] = sorted(dd["defaultClientScopes"])
+
+    assert isinstance(dd, dict)
+    for kk in dd:
+        vv_sorted = sort_json(dd[kk])
+        dd[kk] = vv_sorted
     return dd
 
 

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -1,7 +1,7 @@
 import json
 import os
 import shutil
-from kcfetcher.utils.helper import remove_ids, normalize
+from kcfetcher.utils.helper import remove_ids, normalize, sort_json
 # from tests.integration.test_ping import BaseTestClass
 from pytest import mark
 
@@ -112,3 +112,74 @@ class Test_normalize:
     def test_normalize(self, identifier_in, expected_identifier):
         identifier_out = normalize(identifier_in)
         assert expected_identifier == identifier_out
+
+
+role_in = {
+    "attributes": {
+        "ci0-client0-role1-key0": [
+            "ci0-client0-role1-value0"
+        ]
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "ci0-client0-role1b"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "ci0-client0-role1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "ci0-role-1a"
+        }
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+
+role_out = {
+    "attributes": {
+        "ci0-client0-role1-key0": [
+            "ci0-client0-role1-value0"
+        ]
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "ci0-client0-role1b"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "ci0-client0-role1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "ci0-role-1a"
+        }
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+class Test_sort_data:
+    @mark.parametrize(
+        "data, expected_data",
+        [
+            ("myident", "myident"),
+            (role_in, role_out),
+        ]
+    )
+    def test_sort_data(self, data, expected_data):
+        data_out = sort_json(data)
+        assert expected_data == data_out
+

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -114,7 +114,7 @@ class Test_normalize:
         assert expected_identifier == identifier_out
 
 
-role_in = {
+role_in_abc = {
     "attributes": {
         "ci0-client0-role1-key0": [
             "ci0-client0-role1-value0"
@@ -126,18 +126,105 @@ role_in = {
         {
             "clientRole": True,
             "containerName": "ci0-client-0",
-            "name": "ci0-client0-role1b"
+            "name": "a ci0-client0-role1a"
         },
         {
             "clientRole": True,
             "containerName": "ci0-client-0",
-            "name": "ci0-client0-role1a"
+            "name": "b ci0-client0-role1b"
         },
         {
             "clientRole": True,
             "containerName": "ci0-realm",
-            "name": "ci0-role-1a"
-        }
+            "name": "c ci0-role-1a"
+        },
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+
+role_in_bac = {
+    "attributes": {
+        "ci0-client0-role1-key0": [
+            "ci0-client0-role1-value0"
+        ]
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "b ci0-client0-role1b"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "a ci0-client0-role1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "c ci0-role-1a"
+        },
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+
+role_in_acb = {
+    "attributes": {
+        "ci0-client0-role1-key0": [
+            "ci0-client0-role1-value0"
+        ]
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "a ci0-client0-role1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "c ci0-role-1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "b ci0-client0-role1b"
+        },
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+
+role_in_cba = {
+    "attributes": {
+        "ci0-client0-role1-key0": [
+            "ci0-client0-role1-value0"
+        ]
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "c ci0-role-1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "b ci0-client0-role1b"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "a ci0-client0-role1a"
+        },
     ],
     "description": "ci0-client0-role1-desc",
     "name": "ci0-client0-role1"
@@ -155,31 +242,335 @@ role_out = {
         {
             "clientRole": True,
             "containerName": "ci0-client-0",
-            "name": "ci0-client0-role1b"
+            "name": "a ci0-client0-role1a"
         },
         {
             "clientRole": True,
             "containerName": "ci0-client-0",
-            "name": "ci0-client0-role1a"
+            "name": "b ci0-client0-role1b"
         },
         {
             "clientRole": True,
             "containerName": "ci0-realm",
-            "name": "ci0-role-1a"
-        }
+            "name": "c ci0-role-1a"
+        },
     ],
     "description": "ci0-client0-role1-desc",
     "name": "ci0-client0-role1"
 }
+
+role_out_attr = {
+    "attributes": {
+        "aa key": [
+            "aa value"
+        ],
+        "bb key": [
+            "bb value"
+        ],
+        "cc key": [
+            "cc value"
+        ],
+    },
+    "clientRole": True,
+    "composite": True,
+    "composites": [
+        {
+            "clientRole": True,
+            "containerName": "ci0-realm",
+            "name": "c ci0-role-1a"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "b ci0-client0-role1b"
+        },
+        {
+            "clientRole": True,
+            "containerName": "ci0-client-0",
+            "name": "a ci0-client0-role1a"
+        },
+    ],
+    "description": "ci0-client0-role1-desc",
+    "name": "ci0-client0-role1"
+}
+#
+# role_in_attr_abc = {
+#     "attributes": {
+#         "aa key": [
+#             "aa value"
+#         ],
+#         "bb key": [
+#             "bb value"
+#         ],
+#         "cc key": [
+#             "cc value"
+#         ],
+#     },
+#     "clientRole": True,
+#     "composite": True,
+#     "composites": [
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-realm",
+#             "name": "c ci0-role-1a"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "b ci0-client0-role1b"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "a ci0-client0-role1a"
+#         },
+#     ],
+#     "description": "ci0-client0-role1-desc",
+#     "name": "ci0-client0-role1"
+# }
+#
+# role_in_attr_bac = {
+#     "attributes": {
+#         "bb key": [
+#             "bb value"
+#         ],
+#         "aa key": [
+#             "aa value"
+#         ],
+#         "cc key": [
+#             "cc value"
+#         ],
+#     },
+#     "clientRole": True,
+#     "composite": True,
+#     "composites": [
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-realm",
+#             "name": "c ci0-role-1a"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "b ci0-client0-role1b"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "a ci0-client0-role1a"
+#         },
+#     ],
+#     "description": "ci0-client0-role1-desc",
+#     "name": "ci0-client0-role1"
+# }
+#
+# role_in_attr_acb = {
+#     "attributes": {
+#         "aa key": [
+#             "aa value"
+#         ],
+#         "cc key": [
+#             "cc value"
+#         ],
+#         "bb key": [
+#             "bb value"
+#         ],
+#     },
+#     "clientRole": True,
+#     "composite": True,
+#     "composites": [
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-realm",
+#             "name": "c ci0-role-1a"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "b ci0-client0-role1b"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "a ci0-client0-role1a"
+#         },
+#     ],
+#     "description": "ci0-client0-role1-desc",
+#     "name": "ci0-client0-role1"
+# }
+# role_in_attr_cba = {
+#     "attributes": {
+#         "cc key": [
+#             "cc value"
+#         ],
+#         "bb key": [
+#             "bb value"
+#         ],
+#         "aa key": [
+#             "aa value"
+#         ],
+#     },
+#     "clientRole": True,
+#     "composite": True,
+#     "composites": [
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-realm",
+#             "name": "c ci0-role-1a"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "b ci0-client0-role1b"
+#         },
+#         {
+#             "clientRole": True,
+#             "containerName": "ci0-client-0",
+#             "name": "a ci0-client0-role1a"
+#         },
+#     ],
+#     "description": "ci0-client0-role1-desc",
+#     "name": "ci0-client0-role1"
+# }
+#
+
+# Could be sorted too
+# {
+#     "config": {
+#         "allowed-protocol-mapper-types": [
+#             "saml-role-list-mapper",
+#             "oidc-full-name-mapper",
+#             "oidc-address-mapper",
+#             "oidc-usermodel-attribute-mapper",
+#             "saml-user-attribute-mapper",
+#             "saml-user-property-mapper",
+#             "oidc-usermodel-property-mapper",
+#             "oidc-sha256-pairwise-sub-mapper"
+#         ]
+#     },
+#     "name": "Allowed Protocol Mapper Types",
+#     "parentId": "ci0-realm",
+#     "providerId": "allowed-protocol-mappers",
+#     "providerType": "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+#     "subType": "anonymous"
+# }
+
+# allowed protocol mapper types
+apm_out = {
+    "config": {
+        "allowed-protocol-mapper-types": [
+            'oidc-address-mapper',
+            'oidc-full-name-mapper',
+            'oidc-sha256-pairwise-sub-mapper',
+            'oidc-usermodel-attribute-mapper',
+            'oidc-usermodel-property-mapper',
+            'saml-role-list-mapper',
+            'saml-user-attribute-mapper',
+            'saml-user-property-mapper',
+        ]
+    },
+    "name": "Allowed Protocol Mapper Types",
+    "parentId": "ci0-realm",
+    "providerId": "allowed-protocol-mappers",
+    "providerType": "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+    "subType": "authenticated"
+}
+apm_in_1 = {
+    "config": {
+        "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper"
+        ]
+    },
+    "name": "Allowed Protocol Mapper Types",
+    "parentId": "ci0-realm",
+    "providerId": "allowed-protocol-mappers",
+    "providerType": "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+    "subType": "authenticated"
+}
+apm_in_2 = {
+    "config": {
+        "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-full-name-mapper"
+        ]
+    },
+    "name": "Allowed Protocol Mapper Types",
+    "parentId": "ci0-realm",
+    "providerId": "allowed-protocol-mappers",
+    "providerType": "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+    "subType": "authenticated"
+}
+
+# sort client defaultClientScopes
+dcs_out = {
+    "clientId": "ci0-client-0",
+    "defaultClientScopes": [
+        "email",
+        "profile",
+        "roles",
+        "web-origins",
+    ],
+    "description": "ci0-client-0-desc",
+}
+dcs_in_1 = {
+    "clientId": "ci0-client-0",
+    "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email",
+    ],
+    "description": "ci0-client-0-desc",
+}
+dcs_in_2 = {
+    "clientId": "ci0-client-0",
+    "defaultClientScopes": [
+        "profile",
+        "web-origins",
+        "email",
+        "roles",
+    ],
+    "description": "ci0-client-0-desc",
+}
+
+
 class Test_sort_data:
     @mark.parametrize(
         "data, expected_data",
         [
             ("myident", "myident"),
-            (role_in, role_out),
+            (role_in_abc, role_out),
+            (role_in_bac, role_out),
+            (role_in_acb, role_out),
+            (role_in_cba, role_out),
+            # not needed
+            # (role_in_attr_abc, role_out_attr),
+            # (role_in_attr_bac, role_out_attr),
+            # (role_in_attr_acb, role_out_attr),
+            # (role_in_attr_cba, role_out_attr),
+            #
+            (apm_in_1, apm_out),
+            (apm_in_2, apm_out),
+            (dcs_in_1, dcs_out),
+            (dcs_in_2, dcs_out),
         ]
     )
     def test_sort_data(self, data, expected_data):
         data_out = sort_json(data)
+        # print('='*80)
+        # print(f'data_out={json.dumps(data_out, indent=4)}')
+        # print('='*80)
         assert expected_data == data_out
-


### PR DESCRIPTION
Sort output files for easier comparison

We load same data into  2 different KC servers.
REST responses have a bit different order, and output json files
are then difficult to compare.

Sorting content make comparison easier.
