### PR TITLE
Fix filename normalization

### DIFF
--- a/kcfetcher/fetch/custom_authentication.py
+++ b/kcfetcher/fetch/custom_authentication.py
@@ -1,10 +1,8 @@
 from kcfetcher.fetch import GenericFetch
+from kcfetcher.utils import normalize
 
 
 class CustomAuthenticationFetch(GenericFetch):
-    def normalize(self, identifier=""):
-        return identifier.lower().replace('//', '_').replace(' ', '_')
-
     def fetch(self, store_api):
         name = self.resource_name
         identifier = self.id
@@ -18,7 +16,7 @@ class CustomAuthenticationFetch(GenericFetch):
 
         counter = 0
         for kc_object in kc_objects:
-            store_api.add_child(self.normalize(kc_object[identifier]))  # auth/authentication_name
+            store_api.add_child(normalize(kc_object[identifier]))  # auth/authentication_name
             store_api.store_one(kc_object, identifier)
 
             executors = authentication_api.executions(kc_object).all()

--- a/kcfetcher/utils/helper.py
+++ b/kcfetcher/utils/helper.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 from copy import copy
 
@@ -115,10 +116,8 @@ def login(endpoint, user, password, read_token_from_file=False):
 
 def normalize(identifier=""):
     identifier = identifier.lower()
-    bad_chars = '/ =,:*'
-    for bad_char in bad_chars:
-        identifier = identifier.replace(bad_char, '_')
-    return identifier
+    not_allowed_regex = r"[^a-z0-9.\-_]"
+    return re.sub(not_allowed_regex, "_", identifier)
 
 
 def make_folder(name):

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -108,6 +108,8 @@ class Test_normalize:
             ("http://an.url/can.be/a.name-etc", "http___an.url_can.be_a.name-etc"),
             ("username-with-asterix-*", "username-with-asterix-_"),
             ("aa-#-bb", "aa-_-bb"),
+            ("aa-/-bb", "aa-_-bb"),
+            ("aa-\\-bb", "aa-_-bb"),
         ]
     )
     def test_normalize(self, identifier_in, expected_identifier):

--- a/tests/unit/utils/test_helper.py
+++ b/tests/unit/utils/test_helper.py
@@ -107,6 +107,7 @@ class Test_normalize:
             ("aa/bb cc=dd,ee---aa/bb cc=dd,ee", "aa_bb_cc_dd_ee---aa_bb_cc_dd_ee"),
             ("http://an.url/can.be/a.name-etc", "http___an.url_can.be_a.name-etc"),
             ("username-with-asterix-*", "username-with-asterix-_"),
+            ("aa-#-bb", "aa-_-bb"),
         ]
     )
     def test_normalize(self, identifier_in, expected_identifier):


### PR DESCRIPTION
kcfetcher crashed, from memory it was because of some filename was invalid.

Filename normalization is refactored.
Before we forbid some specific characters.
Now we will allow only "a-z0-9.-_" in filenames.
