### PR TITLE
Sort output

### DIFF
--- a/kcfetcher/fetch/client_scope.py
+++ b/kcfetcher/fetch/client_scope.py
@@ -86,6 +86,7 @@ class DefaultClientScopeFetch(GenericFetch):
         # Response is list of dict, attributes .name and .id
         # In json we want to store only client_scope name.
         data = [obj["name"] for obj in kc_objects]
+        data = sorted(data)
         return data
 
     def fetch(self, store_api):

--- a/kcfetcher/fetch/realm.py
+++ b/kcfetcher/fetch/realm.py
@@ -1,6 +1,8 @@
 import logging
 from copy import copy
 
+from kcfetcher.utils import RH_SSO_VERSIONS_7_4
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,5 +23,9 @@ class RealmFetch():
             # compound_profile_version += ".".join(self.kc.server_info.version.split(".")[:2])
             # assert compound_profile_version in ["community 15.0", "community 18.0", "product 7.5", "product 7.6"]
             realm_min.pop("identityProviders")
+        # defaultRoles list is unordered. We want it sorted in json file.
+        if self.kc.server_info_compound_profile_version() in RH_SSO_VERSIONS_7_4:
+            assert "defaultRoles" in realm_min
+            realm_min["defaultRoles"] = sorted(realm_min["defaultRoles"])
 
         store_api.store_one(realm_min, 'realm')

--- a/kcfetcher/fetch/role.py
+++ b/kcfetcher/fetch/role.py
@@ -21,6 +21,14 @@ and they will be saved to:
 if self.kc.server_info_compound_profile_version() in RH_SSO_VERSIONS_7_4: no code needed
 """
 
+def role_sort_composites(data):
+    assert isinstance(data, list)
+    assert isinstance(data[0], dict)
+    assert "name" in data[0]
+    assert "containerName" in data[0]
+    data = sorted(data, key=lambda obj: (obj["name"], obj["containerName"]))
+    return data
+
 
 # A realm role
 class RoleFetch(GenericFetch):
@@ -68,6 +76,10 @@ class RoleFetch(GenericFetch):
                 assert "composites" not in role
                 composites = roles_by_id_api.get(f"{role_id}/composites").verify().resp().json()
                 role["composites"] = [minimize_role_representation(cc, realms, clients) for cc in composites]
+
+                # master realm, roles/admin.json - composites will contain "manage-authorization" role from multiple clients.
+                # sort list, first by name, then by containerName
+                role["composites"] = role_sort_composites(role["composites"])
 
             roles.append(role)
 

--- a/tests/unit/fetch/test_client_scopes.py
+++ b/tests/unit/fetch/test_client_scopes.py
@@ -103,21 +103,21 @@ class TestClientScopeFetch:
 
         # =====================================================================
         data = json.load(open(os.path.join(datadir, "default/default-default-client-scopes.json")))
-        assert data == unordered([
+        assert data == [
+            "ci0-client-scope",
             "email",
             "profile",
-            "roles",
             "role_list",
+            "roles",
             "web-origins",
-            "ci0-client-scope",
-        ])
+        ]
 
         # =====================================================================
         data = json.load(open(os.path.join(datadir, "default/default-optional-client-scopes.json")))
-        assert data == unordered([
-            "microprofile-jwt",
+        assert data == [
             "address",
-            "phone",
-            "offline_access",
             "ci0-client-scope-1-saml",
-        ])
+            "microprofile-jwt",
+            "offline_access",
+            "phone",
+        ]

--- a/tests/unit/fetch/test_realm.py
+++ b/tests/unit/fetch/test_realm.py
@@ -195,11 +195,11 @@ class TestRealmFetch_vcr:
             }
         ])
         if kc.server_info_compound_profile_version() in RH_SSO_VERSIONS_7_4:
-            assert data["defaultRoles"] == unordered([
+            assert data["defaultRoles"] == [
+                "ci0-role-0",
                 "offline_access",
                 "uma_authorization",
-                "ci0-role-0",
-            ])
+            ]
         else:
             assert kc.server_info_compound_profile_version() in RH_SSO_VERSIONS_7_5
             assert data["defaultRole"] == {
@@ -223,7 +223,7 @@ class TestRealmFetch_vcr:
             # TODO - make this [] in .json file
             expected_realm_attrs.remove("identityProviderMappers")
             assert list(data.keys()) == unordered(expected_realm_attrs)
-            assert data["defaultRoles"] == unordered([
+            assert data["defaultRoles"] == [
                 "offline_access",
                 "uma_authorization",
-            ])
+            ]

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -1,11 +1,81 @@
+from copy import copy
+
 from pytest import mark
 from pytest_unordered import unordered
 import json
 import os
 import shutil
+
+from kcfetcher.fetch.role import role_sort_composites
 from kcfetcher.fetch import RoleFetch
 from kcfetcher.store import Store
 from kcfetcher.utils import remove_folder, make_folder, login, RH_SSO_VERSIONS_7_5
+
+
+class Test_role_sort_composites():
+    @mark.parametrize(
+        "reorder_str",
+        [
+            "0123456",
+            "6543210",
+            "0143256",
+            "0543216",
+            "5601234",
+            "3456012",
+            "1234560",
+            "5643012",
+            "5634012",
+            "5163420",
+            "5263410",
+        ]
+    )
+    def test_role_sort_composites(self, reorder_str):
+        expected_obj = [
+            {
+                "bla": 0,
+                "containerName": "ci0-realm-realm",
+                "name": "create-client"
+            },
+            {
+                "bla": 1,
+                "containerName": "master-realm",
+                "name": "create-client"
+            },
+            {
+                "bla": 2,
+                "containerName": "master",
+                "name": "create-realm"
+            },
+            {
+                "bla": 3,
+                "containerName": "ci0-realm-realm",
+                "name": "impersonation"
+            },
+            {
+                "bla": 4,
+                "containerName": "master-realm",
+                "name": "impersonation"
+            },
+            {
+                "bla": 5,
+                "containerName": "ci0-realm-realm",
+                "name": "manage-authorization"
+            },
+            {
+                "bla": 6,
+                "containerName": "master-realm",
+                "name": "manage-authorization"
+            },
+        ]
+        assert [oo["bla"] for oo in expected_obj] == list(range(len(expected_obj)))
+
+        ind = [int(ch) for ch in reorder_str]
+        set(ind) == set(list(range(len(expected_obj))))
+        in_obj = [copy(expected_obj[ii]) for ii in ind]
+        assert [oo["bla"] for oo in in_obj] == ind
+
+        out_obj = role_sort_composites(in_obj)
+        assert out_obj == expected_obj
 
 
 @mark.vcr()
@@ -68,7 +138,7 @@ class TestRoleFetch_vcr:
         assert data["attributes"] == {"ci0-role-1-key0": ["ci0-role-1-value0"]}
         assert len(data["composites"]) == 3
         #
-        composites_sorted = sorted(data["composites"], key=lambda obj: obj["name"])
+        composites_sorted = data["composites"]  # must be already sorted
         assert list(composites_sorted[0].keys()) == [
             'clientRole',
             # 'composite',
@@ -99,7 +169,7 @@ class TestRoleFetch_vcr:
                 'description',
                 'name',
             ]
-            assert data["composites"] == unordered([
+            assert data["composites"] == [
                 {
                     "clientRole": False,
                     "containerName": "ci0-realm",
@@ -130,4 +200,4 @@ class TestRoleFetch_vcr:
                     "containerName": "ci0-realm",
                     "name": "offline_access"
                 }
-            ])
+            ]

--- a/tests/unit/fetch/test_role.py
+++ b/tests/unit/fetch/test_role.py
@@ -171,6 +171,11 @@ class TestRoleFetch_vcr:
             ]
             assert data["composites"] == [
                 {
+                    "clientRole": True,
+                    "containerName": "ci0-client-0",
+                    "name": "ci0-client0-role0"
+                },
+                {
                     "clientRole": False,
                     "containerName": "ci0-realm",
                     "name": "ci0-role-0"
@@ -181,14 +186,9 @@ class TestRoleFetch_vcr:
                     "name": "manage-account"
                 },
                 {
-                    "clientRole": True,
-                    "containerName": "account",
-                    "name": "view-profile"
-                },
-                {
-                    "clientRole": True,
-                    "containerName": "ci0-client-0",
-                    "name": "ci0-client0-role0"
+                    "clientRole": False,
+                    "containerName": "ci0-realm",
+                    "name": "offline_access"
                 },
                 {
                     "clientRole": False,
@@ -196,8 +196,8 @@ class TestRoleFetch_vcr:
                     "name": "uma_authorization"
                 },
                 {
-                    "clientRole": False,
-                    "containerName": "ci0-realm",
-                    "name": "offline_access"
-                }
+                    "clientRole": True,
+                    "containerName": "account",
+                    "name": "view-profile"
+                },
             ]


### PR DESCRIPTION
We expect same file content if two keycloak servers contain same content.
But some lists in json response are returned in "random" order (likely order is based on object UUID, but we do not store UUIDs to disk).

PR ensures those lists are sorted. This makes output friendly to version control.

